### PR TITLE
Add bwd correctness checking tool for CP = 4 and VSA flex attention reference

### DIFF
--- a/csrc/attn/check_correctness.py
+++ b/csrc/attn/check_correctness.py
@@ -1,0 +1,107 @@
+
+import torch
+import torch.nn.functional as F
+from xformers.ops import fmha, memory_efficient_attention
+from vsa import video_sparse_attn
+from flex_attn_vsa import VSA_attention_flex
+
+def FA3(q, k, v):
+    # FA3
+    output = memory_efficient_attention(q, k, v, attn_bias=None)
+    return output
+
+def torch_attn(q, k, v, head_dim):
+    # torch_attn
+    scores = torch.matmul(q, k.transpose(-2, -1)) / (head_dim ** 0.5)
+    attn = F.softmax(scores, dim=-1)
+    return torch.matmul(attn, v)
+
+def VSA(q,k,v):
+    # VSA
+    output_VSA = video_sparse_attn(q, k, v, topk=topk_blocks, block_size=(4,4,4), compress_attn_weight=0.0)
+    return output_VSA
+
+def VSA_flex(q,k,v):
+    # VSA-flex
+    output_flex = VSA_attention_flex(q,k,v, topk=topk_blocks, block_size=(4,4,4), compress_attn_weight=0.0)
+    return output_flex
+
+# Verify correctness
+
+# setup random seed
+torch.manual_seed(42)
+
+# random inputs
+batch_size = 1
+seq_len = 4096
+head_num = 12
+head_dim = 64
+block_size = 64
+CP = 4 # context parallelism
+q = torch.randn(batch_size, seq_len//CP, head_num, head_dim, requires_grad=True, dtype=torch.bfloat16, device="cuda")
+k = torch.randn(batch_size, seq_len, head_num, head_dim, requires_grad=True, dtype=torch.bfloat16, device="cuda")
+v = torch.randn(batch_size, seq_len, head_num, head_dim, requires_grad=True, dtype=torch.bfloat16, device="cuda")
+topk_blocks = int(seq_len/block_size) # select all blocks, causing dense attention
+print("topk_blocks:", topk_blocks)
+
+# fwd
+output_FA3 = FA3(q, k, v)
+output_torch = torch_attn(q.permute(0,2,1,3), k.permute(0,2,1,3), v.permute(0,2,1,3), head_dim).permute(0,2,1,3)
+output_VSA = VSA(q.permute(0,2,1,3).contiguous(), k.permute(0,2,1,3).contiguous(), v.permute(0,2,1,3).contiguous()).permute(0,2,1,3)
+output_VSA_flex = VSA_flex(q.permute(0,2,1,3), k.permute(0,2,1,3), v.permute(0,2,1,3)).permute(0,2,1,3)
+
+# Verify the fwd consistency with FA3
+print("@fwd, consistent between FA3 and torch_attn:", torch.allclose(output_FA3, output_torch, atol=3e-03, equal_nan=False))
+print("@fwd, consistent between FA3 and FA3 and VSA:", torch.allclose(output_FA3, output_VSA, atol=3e-03, equal_nan=False))
+print("@fwd, consistent between FA3 and FA3 and VSA:", torch.allclose(output_FA3, output_VSA_flex, atol=3e-03, equal_nan=False))
+
+# bwd
+output_grad = torch.randn_like(output_FA3)
+# save grad for FA3
+output_FA3.backward(gradient=output_grad)
+q_grad_FA3 = q.grad.clone()
+k_grad_FA3 = k.grad.clone()
+v_grad_FA3 = v.grad.clone()
+q.grad = None
+k.grad = None
+v.grad = None
+
+# save grad for torch attention
+output_torch.backward(gradient=output_grad)
+q_grad_torch = q.grad.clone()
+k_grad_torch = k.grad.clone()
+v_grad_torch = v.grad.clone()
+q.grad = None
+k.grad = None
+v.grad = None
+
+# save grad for VSA
+output_VSA.backward(gradient=output_grad)
+q_grad_VSA = q.grad.clone()
+k_grad_VSA = k.grad.clone()
+v_grad_VSA = v.grad.clone()
+q.grad = None
+k.grad = None
+v.grad = None
+
+# save grad for VSA_flex
+output_VSA_flex.backward(gradient=output_grad)
+q_grad_VSA_flex = q.grad.clone()
+k_grad_VSA_flex = k.grad.clone()
+v_grad_VSA_flex = v.grad.clone()
+q.grad = None
+k.grad = None
+v.grad = None
+
+# Verify the bwd consistency with FA3
+print("q_grad@bwd, consistent between FA3 and torch_attn:", torch.allclose(q_grad_FA3, q_grad_torch, atol=5e-3, equal_nan=False))
+print("k_grad@bwd, consistent between FA3 and torch_attn:", torch.allclose(k_grad_FA3, k_grad_torch, atol=5e-3, equal_nan=False))
+print("v_grad@bwd, consistent between FA3 and torch_attn:", torch.allclose(v_grad_FA3, v_grad_torch, atol=5e-3, equal_nan=False))
+
+print("q_grad@bwd, consistent between FA3 and VSA:", torch.allclose(q_grad_FA3, q_grad_VSA, atol=5e-3, equal_nan=False))
+print("k_grad@bwd, consistent between FA3 and VSA:", torch.allclose(k_grad_FA3, k_grad_VSA, atol=5e-3, equal_nan=False))
+print("v_grad@bwd, consistent between FA3 and VSA:", torch.allclose(v_grad_FA3, v_grad_VSA, atol=5e-3, equal_nan=False))
+
+print("q_grad@bwd, consistent between FA3 and VSA_flex:", torch.allclose(q_grad_FA3, q_grad_VSA_flex, atol=5e-3, equal_nan=False))
+print("k_grad@bwd, consistent between FA3 and VSA_flex:", torch.allclose(k_grad_FA3, k_grad_VSA_flex, atol=5e-3, equal_nan=False))
+print("v_grad@bwd, consistent between FA3 and VSA_flex:", torch.allclose(v_grad_FA3, v_grad_VSA_flex, atol=5e-3, equal_nan=False))

--- a/csrc/attn/flex_attn_vsa.py
+++ b/csrc/attn/flex_attn_vsa.py
@@ -1,0 +1,152 @@
+from functools import lru_cache
+from logging import getLogger
+from typing import Any, cast, List, Optional, Tuple
+
+import torch
+from torch.nn.attention.flex_attention import flex_attention, create_block_mask
+
+# compile create_block_mask and flex_attention
+cbm_compiled = torch.compile(create_block_mask)
+flex_compiled = torch.compile(flex_attention)
+
+
+try:
+    import xformers
+    from xformers.ops import (
+        AttentionBias,
+        AttentionOp,
+        fmha,
+        memory_efficient_attention,
+    )
+
+    print("using efficient attention")
+
+except (ImportError, ModuleNotFoundError):
+    AttentionOp = Any
+    AttentionBias = Any
+    fmha = None
+    print("no efficient attention")
+
+
+def flex_attention_with_block_mask(query:torch.tensor,
+                                    key:torch.tensor,
+                                    value:torch.tensor,
+                                    mask:torch.tensor,
+                                    BS:int) -> torch.Tensor:
+    """
+    FlexAttention-style sparse block attention.
+    q: torch.tensor, [B, H, Nq, d]
+    k: torch.tensor, [B, H, Nk, d]
+    v: torch.tensor, [B, H, Nv, d]
+    mask: torch.tensor, [B, H, nq, nk]
+    BS: block size
+    """
+
+    B, H, Nq, d = query.shape
+    _, _, Nk, _ = key.shape
+
+    def search_mask(b, h, q_idx, k_idx, BS=BS, mask=mask):
+        q_blk_idx = q_idx // BS
+        k_blk_idx = k_idx // BS
+        return (mask[b, h, q_blk_idx, k_blk_idx] > 0.).to(torch.bool) # indicate this is an active block
+
+    block_mask = cbm_compiled(search_mask, B, H, Nq, Nk, device="cuda")
+    output = flex_compiled(query, key, value, block_mask=block_mask)
+
+    return output
+
+
+def torch_attention(q, k, v) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    q: torch.tensor, [B, H, Nq, d]
+    k: torch.tensor, [B, H, Nk, d]
+    v: torch.tensor, [B, H, Nv, d]
+    """
+    QK = torch.matmul(q, k.transpose(-2, -1))
+    QK /= (q.size(-1)**0.5)
+
+    # Causal mask removed since causal is always false
+    QK = torch.nn.functional.softmax(QK, dim=-1)
+    output = torch.matmul(QK, v)
+    return output, QK
+
+
+def VSA_attention_flex(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    p: float = 0.0,
+    op: Optional[AttentionOp] = None,
+    use_fp8: bool = False,
+    topk: int = 1,
+    block_size: list[int] = [4, 4, 4],  # (B_T, B_H, B_W)
+    compress_attn_weight=0.0,
+):
+    """
+    query: torch.Tensor, [batch_size, num_heads, query_seq_len, head_dim]
+    key: torch.Tensor, [batch_size, num_heads, kv_seq_len, head_dim]
+    value: torch.Tensor, [batch_size, num_heads, kv_seq_len, head_dim]
+
+    Definitions:
+    Hybrid Attention Module with 3D block
+    block_size: (block_size_t, block_size_h, block_size_w)
+    block_num: (num_blocks_t, num_blocks_h, num_blocks_w)
+    """
+
+    # check shape of query, key, value
+    batch_size, num_heads, query_seq_len, head_dim = query.shape
+    _, _, kv_seq_len, _ = key.shape
+
+    # block volume
+    block_volume = block_size[0] * block_size[1] * block_size[2]
+
+    # here, we assume qkv has been rearranged
+    q_compress = query.view(
+        batch_size, num_heads, query_seq_len // block_volume, block_volume, head_dim
+    ).mean(
+        dim=3
+    )  # comp_q (B, H, n_q, d)
+    k_compress = key.view(
+        batch_size, num_heads, kv_seq_len // block_volume, block_volume, head_dim
+    ).mean(
+        dim=3
+    )  # comp_k (B, H, n_kv, d)
+    v_compress = value.view(
+        batch_size, num_heads, kv_seq_len // block_volume, block_volume,  head_dim
+    ).mean(
+        dim=3
+    )  # comp_v (B, H, n_kv, d)
+
+    output_compress, block_attn_score = torch_attention(
+        q_compress,
+        k_compress,
+        v_compress,
+    )  # (B H nq d)(B H nq nk)
+
+    output_coarse = (
+        output_compress.permute(0, 2, 1, 3)
+        .unsqueeze(2)
+        .repeat(1, 1, block_volume, 1, 1)
+        .view(query.shape)
+    ) # B H Nq d
+
+    print("output_coarse.shape", output_coarse.shape)
+
+    # Topk Selection
+    _, topk_indices = torch.topk(block_attn_score, topk, dim=-1)
+    masked_A_compress = torch.zeros_like(block_attn_score)  # B H nq nk
+    masked_A_compress.scatter_(-1, topk_indices, 1)  # B H nq nk
+
+    output_fine = flex_attention_with_block_mask(
+        query=query,
+        key=key,
+        value=value,
+        mask=masked_A_compress,
+        BS=block_volume,
+    ) # B H Nq d
+
+    # Combine
+    # print("output_fine.shape", output_fine.shape)
+    output = compress_attn_weight * output_coarse + (1 - compress_attn_weight) * output_fine # B H Nq d
+
+    return output

--- a/csrc/attn/setup_vsa.py
+++ b/csrc/attn/setup_vsa.py
@@ -64,7 +64,8 @@ setup(name=PACKAGE_NAME,
                             'cxx': cpp_flags,
                             'nvcc': cuda_flags
                         },
-                        libraries=['cuda'])
+                        libraries=['cuda'],
+                        library_dirs=['/usr/local/cuda-12.6/targets/x86_64-linux/lib/stubs'])
       ],
       cmdclass={'build_ext': BuildExtension},
       classifiers=[

--- a/csrc/attn/vsa/__init__.py
+++ b/csrc/attn/vsa/__init__.py
@@ -23,8 +23,8 @@ def video_sparse_attn(q, k, v, topk, block_size, compress_attn_weight=None):
     video_shape: tuple of (T, H, W)
     compress_attn_weight: [batch_size, num_heads, seq_len, head_dim]
     select_attn_weight: [batch_size, num_heads, seq_len, head_dim]
-    
-    V1 of sparse attention. Include compress attn and sparse attn branch, use average pooling to compress. 
+
+    V1 of sparse attention. Include compress attn and sparse attn branch, use average pooling to compress.
     Assume q, k, v is flattened in this way: [batch_size, num_heads, T//block_size[0], H//block_size[1], W//block_size[2], block_size[0], block_size[1], block_size[2]]
     """
 
@@ -35,12 +35,13 @@ def video_sparse_attn(q, k, v, topk, block_size, compress_attn_weight=None):
     assert block_elements % 64 == 0 and block_elements >= 64
     assert q.shape[2] % block_elements == 0
     batch_size, num_heads, seq_len, head_dim = q.shape
+    _, _, kv_len, head_dim = k.shape
     # compress attn
     q_compress = q.view(batch_size, num_heads, seq_len // block_elements,
                         block_elements, head_dim).mean(dim=3)
-    k_compress = k.view(batch_size, num_heads, seq_len // block_elements,
+    k_compress = k.view(batch_size, num_heads, kv_len // block_elements,
                         block_elements, head_dim).mean(dim=3)
-    v_compress = v.view(batch_size, num_heads, seq_len // block_elements,
+    v_compress = v.view(batch_size, num_heads, kv_len // block_elements,
                         block_elements, head_dim).mean(dim=3)
 
     output_compress, block_attn_score = torch_attention(q_compress, k_compress,
@@ -82,13 +83,13 @@ def generate_topk_block_sparse_pattern(block_attn_score: torch.Tensor,
     """
     Generate a block sparse pattern where each q block attends to exactly topk kv blocks,
     based on the provided attention scores.
-    
+
     Args:
         block_attn_score: [bs, h, num_q_blocks, num_kv_blocks]
             Attention scores between query and key blocks
         topk: int
             Number of kv blocks each q block attends to
-        
+
     Returns:
         q2k_block_sparse_index: [bs, h, num_q_blocks, topk]
             Contains the indices of kv blocks that each q block attends to.
@@ -127,7 +128,7 @@ def generate_topk_block_sparse_pattern(block_attn_score: torch.Tensor,
 def block_sparse_attn(q, k, v, q2k_block_sparse_index, q2k_block_sparse_num, k2q_block_sparse_index, k2q_block_sparse_num):
     """
     Differentiable block sparse attention function.
-    
+
     Args:
         q: Query tensor [batch_size, num_heads, seq_len_q, head_dim]
         k: Key tensor [batch_size, num_heads, seq_len_kv, head_dim]
@@ -136,7 +137,7 @@ def block_sparse_attn(q, k, v, q2k_block_sparse_index, q2k_block_sparse_num, k2q
         q2k_block_sparse_num: Number of sparse blocks for each query block
         k2q_block_sparse_index: Indices for key-to-query sparse blocks (for backward pass)
         k2q_block_sparse_num: Number of sparse blocks for each key block (for backward pass)
-    
+
     Returns:
         output: Attention output tensor [batch_size, num_heads, seq_len_q, head_dim]
     """
@@ -146,7 +147,7 @@ def block_sparse_attn(q, k, v, q2k_block_sparse_index, q2k_block_sparse_num, k2q
 
 def block_sparse_attention_fwd(q, k, v, q2k_block_sparse_index, q2k_block_sparse_num):
     """
-    block_sparse_mask: [bs, h, num_q_blocks, num_kv_blocks]. 
+    block_sparse_mask: [bs, h, num_q_blocks, num_kv_blocks].
         [*, *, i, j] = 1 means the i-th q block should attend to the j-th kv block.
     """
     # assert all elements in q2k_block_sparse_num can be devisible by 2
@@ -196,11 +197,11 @@ def index_to_mask_kernel(
 def index_to_mask(q2k_block_sparse_index, q2k_block_sparse_num, BLOCK_Q, BLOCK_K, num_k_blocks):
     """
     Convert block sparse indices to a mask.
-    
+
     Args:
         q2k_block_sparse_index: Indices for query-to-key sparse blocks
         q2k_block_sparse_num: Number of sparse blocks for each query block
-    
+
     Returns:
         mask: Block sparse mask tensor
     """
@@ -285,7 +286,7 @@ def topk_index_to_map(index: torch.Tensor,
                       transpose_map: bool = False):
     """
     Convert topk indices to a map.
-    
+
     Args:
         index: [bs, h, num_q_blocks, topk]
             The topk indices tensor.
@@ -293,7 +294,7 @@ def topk_index_to_map(index: torch.Tensor,
             The number of key-value blocks in the block_map returned
         transpose_map: bool
             If True, the block_map will be transposed on the final two dimensions.
-    
+
     Returns:
         block_map: [bs, h, num_q_blocks, num_kv_blocks]
             A binary map where 1 indicates that the q block attends to the kv block.
@@ -330,11 +331,11 @@ def topk_index_to_map(index: torch.Tensor,
 def map_to_index(block_map: torch.Tensor):
     """
     Convert a block map to indices and counts.
-    
+
     Args:
         block_map: [bs, h, num_q_blocks, num_kv_blocks]
             The block map tensor.
-    
+
     Returns:
         index: [bs, h, num_q_blocks, num_kv_blocks]
             The indices of the blocks.
@@ -426,13 +427,13 @@ class CheckpointSDPA(torch.autograd.Function):
 class BlockSparseAttnTorch:
     def __init__(self):
         self.ctx = None
-    
+
     def recompute_mask(self, _):
         recomputed_mask = index_to_mask(self.q2k_block_sparse_index, self.q2k_block_sparse_num, self.block_q, self.block_k, self.num_kv_blocks)
         mask_size = recomputed_mask.untyped_storage().size()
         self.mask.untyped_storage().resize_(mask_size)
-        self.mask.untyped_storage().copy_(recomputed_mask.untyped_storage()) 
-    
+        self.mask.untyped_storage().copy_(recomputed_mask.untyped_storage())
+
     def recompute(self, _):
         q, k, v, q2k_block_sparse_index, q2k_block_sparse_num = self.ctx.saved_tensors
         block_q = self.ctx.block_q
@@ -447,7 +448,7 @@ class BlockSparseAttnTorch:
     def forward(self, q, k, v, q2k_block_sparse_index, q2k_block_sparse_num, block_q, block_k):
         """
         Differentiable block sparse attention function using PyTorch.
-        
+
         Args:
             q: Query tensor [batch_size, num_heads, seq_len_q, head_dim]
             k: Key tensor [batch_size, num_heads, seq_len_kv, head_dim]

--- a/csrc/attn/vsa/block_sparse_h100.cu
+++ b/csrc/attn/vsa/block_sparse_h100.cu
@@ -1,1351 +1,1594 @@
 // # Define TORCH_COMPILE macro
 
 #include "kittens.cuh"
+#include <c10/cuda/CUDAGuard.h>
 #include <cooperative_groups.h>
 #include <iostream>
-#include <c10/cuda/CUDAGuard.h>
-
 
 using namespace kittens;
 namespace cg = cooperative_groups;
-constexpr int BLOCK_M             = 64;
-constexpr int BLOCK_N             = 64;
-template<int D> struct fwd_attend_ker_tile_dims {};
-template<> struct fwd_attend_ker_tile_dims<64> {
-    constexpr static int tile_width = (64);
-    constexpr static int qo_height  = (4*16);
-    constexpr static int kv_height  = (4*16);
+constexpr int BLOCK_M = 64;
+constexpr int BLOCK_N = 64;
+constexpr int CP = 4;
+template <int D> struct fwd_attend_ker_tile_dims {};
+template <> struct fwd_attend_ker_tile_dims<64> {
+  constexpr static int tile_width = (64);
+  constexpr static int qo_height = (4 * 16);
+  constexpr static int kv_height = (4 * 16);
 };
-template<> struct fwd_attend_ker_tile_dims<128> {
-    constexpr static int tile_width = (128);
-    constexpr static int qo_height  = (4*16);
-    constexpr static int kv_height  = (4*16);
+template <> struct fwd_attend_ker_tile_dims<128> {
+  constexpr static int tile_width = (128);
+  constexpr static int qo_height = (4 * 16);
+  constexpr static int kv_height = (4 * 16);
 };
-template<int D> struct fwd_globals {
-    using q_tile    =         st_bf<fwd_attend_ker_tile_dims<D>::qo_height, fwd_attend_ker_tile_dims<D>::tile_width>;
-    using k_tile    =         st_bf<fwd_attend_ker_tile_dims<D>::kv_height, fwd_attend_ker_tile_dims<D>::tile_width>;
-    using v_tile    =         st_bf<fwd_attend_ker_tile_dims<D>::kv_height, fwd_attend_ker_tile_dims<D>::tile_width>;
-    using l_col_vec = col_vec<st_fl<fwd_attend_ker_tile_dims<D>::qo_height, fwd_attend_ker_tile_dims<D>::tile_width>>;
-    using o_tile    =         st_bf<fwd_attend_ker_tile_dims<D>::qo_height, fwd_attend_ker_tile_dims<D>::tile_width>;
+template <int D> struct fwd_globals {
+  using q_tile = st_bf<fwd_attend_ker_tile_dims<D>::qo_height,
+                       fwd_attend_ker_tile_dims<D>::tile_width>;
+  using k_tile = st_bf<fwd_attend_ker_tile_dims<D>::kv_height,
+                       fwd_attend_ker_tile_dims<D>::tile_width>;
+  using v_tile = st_bf<fwd_attend_ker_tile_dims<D>::kv_height,
+                       fwd_attend_ker_tile_dims<D>::tile_width>;
+  using l_col_vec = col_vec<st_fl<fwd_attend_ker_tile_dims<D>::qo_height,
+                                  fwd_attend_ker_tile_dims<D>::tile_width>>;
+  using o_tile = st_bf<fwd_attend_ker_tile_dims<D>::qo_height,
+                       fwd_attend_ker_tile_dims<D>::tile_width>;
 
-    using q_gl = gl<bf16,  -1, -1, -1, -1, q_tile>;
-    using k_gl = gl<bf16,  -1, -1, -1, -1, k_tile>;
-    using v_gl = gl<bf16,  -1, -1, -1, -1, v_tile>;
-    using l_gl = gl<float, -1, -1, -1, -1, l_col_vec>;
-    using o_gl = gl<bf16,  -1, -1, -1, -1, o_tile>;
+  using q_gl = gl<bf16, -1, -1, -1, -1, q_tile>;
+  using k_gl = gl<bf16, -1, -1, -1, -1, k_tile>;
+  using v_gl = gl<bf16, -1, -1, -1, -1, v_tile>;
+  using l_gl = gl<float, -1, -1, -1, -1, l_col_vec>;
+  using o_gl = gl<bf16, -1, -1, -1, -1, o_tile>;
 
-    q_gl q;
-    k_gl k;
-    v_gl v;
-    l_gl l;
-    o_gl o;
+  q_gl q;
+  k_gl k;
+  v_gl v;
+  l_gl l;
+  o_gl o;
 
-    const int N; 
-    const int hr;
-    const int max_kv_blocks_per_q;
+  const int N;
+  const int hr;
+  const int max_kv_blocks_per_q;
 
-    int32_t *__restrict__  q2k_block_sparse_index;
-    int32_t *__restrict__  q2k_block_sparse_num;
+  int32_t *__restrict__ q2k_block_sparse_index;
+  int32_t *__restrict__ q2k_block_sparse_num;
 };
 
-template<int D>
-__global__  __launch_bounds__(128, 3) // encourage compiler to reduce register usage so that an SM can hold 3 CTAs. Performance will drop from 391T to 353T if not specified explicitly.
-void fwd_attend_ker_even(const __grid_constant__ fwd_globals<D> g) {
-    extern __shared__ int __shm[]; 
-    tma_swizzle_allocator al((int*)&__shm[0]);
+template <int D>
+__global__
+__launch_bounds__(128, 3) // encourage compiler to reduce register usage so that
+                          // an SM can hold 3 CTAs. Performance will drop from
+                          // 391T to 353T if not specified explicitly.
+    void fwd_attend_ker_even(const __grid_constant__ fwd_globals<D> g) {
+  extern __shared__ int __shm[];
+  tma_swizzle_allocator al((int *)&__shm[0]);
 
-    using K = fwd_attend_ker_tile_dims<D>;
+  using K = fwd_attend_ker_tile_dims<D>;
 
-    using q_tile    =         st_bf<64, K::tile_width>;
-    using k_tile    =         st_bf<128, K::tile_width>;
-    using v_tile    =         st_bf<128, K::tile_width>;
-    using k_tile_half    =         st_bf<64, K::tile_width>;
-    using v_tile_half    =         st_bf<64, K::tile_width>;
-    using l_col_vec = col_vec<st_fl<64, K::tile_width>>;
-    using o_tile    =         st_bf<64, K::tile_width>;
-    
-    q_tile    (&q_smem)[1] = al.allocate<q_tile, 1>();
+  using q_tile = st_bf<64, K::tile_width>;
+  using k_tile = st_bf<128, K::tile_width>;
+  using v_tile = st_bf<128, K::tile_width>;
+  using k_tile_half = st_bf<64, K::tile_width>;
+  using v_tile_half = st_bf<64, K::tile_width>;
+  using l_col_vec = col_vec<st_fl<64, K::tile_width>>;
+  using o_tile = st_bf<64, K::tile_width>;
 
-    k_tile_half    (&k_smem_0)[1]           = al.allocate<k_tile_half, 1          >();
-    k_tile_half    (&k_smem_1)[1]           = al.allocate<k_tile_half, 1          >();
-    k_tile    (*k_smem)           = reinterpret_cast<k_tile(*)>(k_smem_0);
+  q_tile(&q_smem)[1] = al.allocate<q_tile, 1>();
 
-    v_tile_half    (&v_smem_0)[1]           = al.allocate<v_tile_half, 1          >();
-    v_tile_half    (&v_smem_1)[1]           = al.allocate<v_tile_half, 1          >();
-    v_tile    (*v_smem)           = reinterpret_cast<v_tile(*)>(v_smem_0);
+  k_tile_half(&k_smem_0)[1] = al.allocate<k_tile_half, 1>();
+  k_tile_half(&k_smem_1)[1] = al.allocate<k_tile_half, 1>();
+  k_tile(*k_smem) = reinterpret_cast<k_tile(*)>(k_smem_0);
 
-    l_col_vec (&l_smem)[1] = al.allocate<l_col_vec, 1>();
+  v_tile_half(&v_smem_0)[1] = al.allocate<v_tile_half, 1>();
+  v_tile_half(&v_smem_1)[1] = al.allocate<v_tile_half, 1>();
+  v_tile(*v_smem) = reinterpret_cast<v_tile(*)>(v_smem_0);
 
-    auto      (*o_smem)                      = reinterpret_cast<o_tile(*)>(q_smem);
-    
-    int kv_head_idx = blockIdx.y / g.hr;
-    int seq_idx     = blockIdx.x; 
+  l_col_vec(&l_smem)[1] = al.allocate<l_col_vec, 1>();
 
+  auto(*o_smem) = reinterpret_cast<o_tile(*)>(q_smem);
 
-    int32_t* q2k_block_sparse_index_ptr = g.q2k_block_sparse_index + blockIdx.z * gridDim.y * gridDim.x * g.max_kv_blocks_per_q + blockIdx.y * gridDim.x * g.max_kv_blocks_per_q  + blockIdx.x * g.max_kv_blocks_per_q;
-    int32_t* q2k_block_sparse_num_ptr = g.q2k_block_sparse_num + blockIdx.z * gridDim.y * gridDim.x  + blockIdx.y * gridDim.x + blockIdx.x;
-    int32_t kv_blocks   = q2k_block_sparse_num_ptr[0] / 2; // each iter load 2 kv blocks
-    __shared__ kittens::semaphore qsmem_semaphore, k_smem_arrived, v_smem_arrived;
+  int kv_head_idx = blockIdx.y / g.hr;
+  int seq_idx = blockIdx.x;
+
+  int32_t *q2k_block_sparse_index_ptr =
+      g.q2k_block_sparse_index +
+      blockIdx.z * gridDim.y * gridDim.x * g.max_kv_blocks_per_q +
+      blockIdx.y * gridDim.x * g.max_kv_blocks_per_q +
+      blockIdx.x * g.max_kv_blocks_per_q;
+  int32_t *q2k_block_sparse_num_ptr = g.q2k_block_sparse_num +
+                                      blockIdx.z * gridDim.y * gridDim.x +
+                                      blockIdx.y * gridDim.x + blockIdx.x;
+  int32_t kv_blocks =
+      q2k_block_sparse_num_ptr[0] / 2; // each iter load 2 kv blocks
+  __shared__ kittens::semaphore qsmem_semaphore, k_smem_arrived, v_smem_arrived;
+  if (threadIdx.x == 0) {
+    int32_t kv_block_index[2];
+    reinterpret_cast<float2 *>(kv_block_index)[0] =
+        reinterpret_cast<float2 *>(q2k_block_sparse_index_ptr)[0];
+
+    init_semaphore(qsmem_semaphore, 0, 1);
+    init_semaphore(k_smem_arrived, 0, 1);
+    init_semaphore(v_smem_arrived, 0, 1);
+
+    // preload q block
+    coord<q_tile> q_tile_idx = {blockIdx.z, blockIdx.y, seq_idx, 0};
+    tma::expect_bytes(qsmem_semaphore, sizeof(q_smem));
+    tma::load_async(q_smem[0], g.q, q_tile_idx, qsmem_semaphore);
+
+    // preload the zeroth block of kv
+    tma::expect_bytes(k_smem_arrived, sizeof(k_tile));
+    coord<k_tile_half> k_tile_idx_0 = {blockIdx.z, kv_head_idx,
+                                       kv_block_index[0], 0};
+    coord<k_tile_half> k_tile_idx_1 = {blockIdx.z, kv_head_idx,
+                                       kv_block_index[1], 0};
+    tma::load_async(k_smem_0[0], g.k, k_tile_idx_0, k_smem_arrived);
+    tma::load_async(k_smem_1[0], g.k, k_tile_idx_1, k_smem_arrived);
+
+    tma::expect_bytes(v_smem_arrived, sizeof(v_tile));
+    coord<v_tile_half> v_tile_idx_0 = {blockIdx.z, kv_head_idx,
+                                       kv_block_index[0], 0};
+    coord<v_tile_half> v_tile_idx_1 = {blockIdx.z, kv_head_idx,
+                                       kv_block_index[1], 0};
+    tma::load_async(v_smem_0[0], g.v, v_tile_idx_0, v_smem_arrived);
+    tma::load_async(v_smem_1[0], g.v, v_tile_idx_1, v_smem_arrived);
+  }
+  __syncthreads();
+
+  rt_fl<16, 128> att_block;
+  rt_bf<16, 128> att_block_mma;
+  rt_fl<16, K::tile_width> o_reg;
+
+  col_vec<rt_fl<16, 128>> max_vec, norm_vec, max_vec_last_scaled,
+      max_vec_scaled;
+
+  neg_infty(max_vec);
+  zero(norm_vec);
+  zero(o_reg);
+
+  // wait for q block
+  kittens::wait(qsmem_semaphore, 0);
+
+  for (int kv_idx = 0; kv_idx < kv_blocks - 1; kv_idx++) {
+    // preload kv index
+    int32_t kv_block_index[2];
+    reinterpret_cast<float2 *>(kv_block_index)[0] =
+        reinterpret_cast<float2 *>(q2k_block_sparse_index_ptr)[kv_idx + 1];
+
+    // wait k
+    kittens::wait(k_smem_arrived, kv_idx % 2);
+
+    // compute QK^T
+    warpgroup::mm_ABt(att_block, q_smem[0], k_smem[0]);
+
+    copy(max_vec_last_scaled, max_vec);
+    if constexpr (D == 64) {
+      mul(max_vec_last_scaled, max_vec_last_scaled, 1.44269504089f * 0.125f);
+    } else {
+      mul(max_vec_last_scaled, max_vec_last_scaled,
+          1.44269504089f * 0.08838834764f);
+    }
+
+    warpgroup::mma_async_wait();
+
+    // load K
     if (threadIdx.x == 0) {
-        int32_t kv_block_index[2];
-        reinterpret_cast<float2*>(kv_block_index)[0] = reinterpret_cast<float2*>(q2k_block_sparse_index_ptr)[0];
-        
-        init_semaphore(qsmem_semaphore, 0, 1);
-        init_semaphore(k_smem_arrived, 0, 1);
-        init_semaphore(v_smem_arrived, 0, 1);
-        
-        // preload q block
-        coord<q_tile> q_tile_idx = {blockIdx.z, blockIdx.y, seq_idx, 0};
-        tma::expect_bytes(qsmem_semaphore, sizeof(q_smem));
-        tma::load_async(q_smem[0], g.q, q_tile_idx, qsmem_semaphore);
-        
-        // preload the zeroth block of kv
-        tma::expect_bytes(k_smem_arrived, sizeof(k_tile));
-        coord<k_tile_half> k_tile_idx_0 = {blockIdx.z, kv_head_idx, kv_block_index[0], 0};
-        coord<k_tile_half> k_tile_idx_1 = {blockIdx.z, kv_head_idx, kv_block_index[1], 0};
-        tma::load_async(k_smem_0[0], g.k, k_tile_idx_0, k_smem_arrived);
-        tma::load_async(k_smem_1[0], g.k, k_tile_idx_1, k_smem_arrived);
-
-        tma::expect_bytes(v_smem_arrived, sizeof(v_tile));
-        coord<v_tile_half> v_tile_idx_0 = {blockIdx.z, kv_head_idx, kv_block_index[0], 0};
-        coord<v_tile_half> v_tile_idx_1 = {blockIdx.z, kv_head_idx, kv_block_index[1], 0};
-        tma::load_async(v_smem_0[0], g.v, v_tile_idx_0, v_smem_arrived);
-        tma::load_async(v_smem_1[0], g.v, v_tile_idx_1, v_smem_arrived);
-    }
-    __syncthreads(); 
-
-    rt_fl<16, 128>  att_block;
-    rt_bf<16, 128>  att_block_mma;
-    rt_fl<16, K::tile_width> o_reg;
-    
-    col_vec<rt_fl<16, 128>> max_vec, norm_vec, max_vec_last_scaled, max_vec_scaled;
-    
-    neg_infty(max_vec);
-    zero(norm_vec);
-    zero(o_reg);
-
-    // wait for q block
-    wait(qsmem_semaphore, 0);
-
-    for (int kv_idx = 0; kv_idx < kv_blocks - 1; kv_idx++) {
-        // preload kv index
-        int32_t kv_block_index[2];
-        reinterpret_cast<float2*>(kv_block_index)[0] = reinterpret_cast<float2*>(q2k_block_sparse_index_ptr)[kv_idx + 1];
-        
-        // wait k
-        wait(k_smem_arrived, kv_idx % 2);
-
-        // compute QK^T
-        warpgroup::mm_ABt(att_block, q_smem[0], k_smem[0]);
-
-        copy(max_vec_last_scaled, max_vec);
-        if constexpr (D == 64) { mul(max_vec_last_scaled, max_vec_last_scaled, 1.44269504089f*0.125f); }
-        else                   { mul(max_vec_last_scaled, max_vec_last_scaled, 1.44269504089f*0.08838834764f); }
-        
-        warpgroup::mma_async_wait();
-
-        // load K
-        if (threadIdx.x == 0) {
-            tma::expect_bytes(k_smem_arrived, sizeof(k_tile));
-            coord<k_tile_half> k_tile_idx_0 = {blockIdx.z, kv_head_idx, kv_block_index[0], 0};
-            coord<k_tile_half> k_tile_idx_1 = {blockIdx.z, kv_head_idx, kv_block_index[1], 0};
-            tma::load_async(k_smem_0[0], g.k, k_tile_idx_0, k_smem_arrived);
-            tma::load_async(k_smem_1[0], g.k, k_tile_idx_1, k_smem_arrived);
-        }
-
-        // exp
-        row_max(max_vec, att_block, max_vec);
-            
-        if constexpr (D == 64) { 
-            mul(att_block, att_block,    1.44269504089f*0.125f); 
-            mul(max_vec_scaled, max_vec, 1.44269504089f*0.125f);
-        }
-        else                   { 
-            mul(att_block, att_block,    1.44269504089f*0.08838834764f); 
-            mul(max_vec_scaled, max_vec, 1.44269504089f*0.08838834764f);
-        }
-
-        sub_row(att_block, att_block, max_vec_scaled);
-        exp2(att_block, att_block);
-        sub(max_vec_last_scaled, max_vec_last_scaled, max_vec_scaled);
-        exp2(max_vec_last_scaled,       max_vec_last_scaled);
-        mul(norm_vec,            norm_vec,     max_vec_last_scaled);
-        row_sum(norm_vec,  att_block, norm_vec);
-        add(att_block, att_block, 0.f);
-        copy(att_block_mma, att_block);
-        mul_row(o_reg, o_reg, max_vec_last_scaled); 
-        
-        // wait v
-        wait(v_smem_arrived, kv_idx % 2);
-
-        // compute SV
-        warpgroup::mma_AB(o_reg, att_block_mma, v_smem[0]);
-        warpgroup::mma_async_wait();
-
-        // load V
-        if (threadIdx.x == 0) {
-            tma::expect_bytes(v_smem_arrived, sizeof(v_tile));
-            // coord<v_tile> v_tile_idx = {blockIdx.z, kv_head_idx, kv_idx + 1, 0};
-            // tma::load_async(v_smem[0], g.v, v_tile_idx, v_smem_arrived);
-            coord<v_tile_half> v_tile_idx_0 = {blockIdx.z, kv_head_idx, kv_block_index[0], 0};
-            coord<v_tile_half> v_tile_idx_1 = {blockIdx.z, kv_head_idx, kv_block_index[1], 0};
-            tma::load_async(v_smem_0[0], g.v, v_tile_idx_0, v_smem_arrived);
-            tma::load_async(v_smem_1[0], g.v, v_tile_idx_1, v_smem_arrived);
-        }
+      tma::expect_bytes(k_smem_arrived, sizeof(k_tile));
+      coord<k_tile_half> k_tile_idx_0 = {blockIdx.z, kv_head_idx,
+                                         kv_block_index[0], 0};
+      coord<k_tile_half> k_tile_idx_1 = {blockIdx.z, kv_head_idx,
+                                         kv_block_index[1], 0};
+      tma::load_async(k_smem_0[0], g.k, k_tile_idx_0, k_smem_arrived);
+      tma::load_async(k_smem_1[0], g.k, k_tile_idx_1, k_smem_arrived);
     }
 
-    // last iter
-    {
-        int kv_idx = kv_blocks - 1;
-        // wait k
-        wait(k_smem_arrived, kv_idx % 2);
+    // exp
+    row_max(max_vec, att_block, max_vec);
 
-        // compute QK^T
-        warpgroup::mm_ABt(att_block, q_smem[0], k_smem[0]);
-
-        copy(max_vec_last_scaled, max_vec);
-        if constexpr (D == 64) { mul(max_vec_last_scaled, max_vec_last_scaled, 1.44269504089f*0.125f); }
-        else                   { mul(max_vec_last_scaled, max_vec_last_scaled, 1.44269504089f*0.08838834764f); }
-        
-        warpgroup::mma_async_wait();      
-
-        // exp
-        row_max(max_vec, att_block, max_vec);
-            
-        if constexpr (D == 64) { 
-            mul(att_block, att_block,    1.44269504089f*0.125f); 
-            mul(max_vec_scaled, max_vec, 1.44269504089f*0.125f);
-        }
-        else                   { 
-            mul(att_block, att_block,    1.44269504089f*0.08838834764f); 
-            mul(max_vec_scaled, max_vec, 1.44269504089f*0.08838834764f);
-        }
-
-        sub_row(att_block, att_block, max_vec_scaled);
-        exp2(att_block, att_block);
-        sub(max_vec_last_scaled, max_vec_last_scaled, max_vec_scaled);
-        exp2(max_vec_last_scaled,       max_vec_last_scaled);
-        mul(norm_vec,            norm_vec,     max_vec_last_scaled);
-        row_sum(norm_vec,  att_block, norm_vec);
-        add(att_block, att_block, 0.f);
-        copy(att_block_mma, att_block); 
-        mul_row(o_reg, o_reg, max_vec_last_scaled); 
-        
-        // wait v
-        wait(v_smem_arrived, kv_idx % 2);
-
-        // compute SV
-        warpgroup::mma_AB(o_reg, att_block_mma, v_smem[0]);
-        warpgroup::mma_async_wait();
+    if constexpr (D == 64) {
+      mul(att_block, att_block, 1.44269504089f * 0.125f);
+      mul(max_vec_scaled, max_vec, 1.44269504089f * 0.125f);
+    } else {
+      mul(att_block, att_block, 1.44269504089f * 0.08838834764f);
+      mul(max_vec_scaled, max_vec, 1.44269504089f * 0.08838834764f);
     }
 
-    div_row(o_reg, o_reg, norm_vec);
-    warpgroup::store(o_smem[0], o_reg); 
-    __syncthreads();
+    sub_row(att_block, att_block, max_vec_scaled);
+    exp2(att_block, att_block);
+    sub(max_vec_last_scaled, max_vec_last_scaled, max_vec_scaled);
+    exp2(max_vec_last_scaled, max_vec_last_scaled);
+    mul(norm_vec, norm_vec, max_vec_last_scaled);
+    row_sum(norm_vec, att_block, norm_vec);
+    add(att_block, att_block, 0.f);
+    copy(att_block_mma, att_block);
+    mul_row(o_reg, o_reg, max_vec_last_scaled);
 
-    // TK store_async internally calls syncwarp so we need to route on warp level
-    if (threadIdx.x / 32 == 0) {
-        coord<o_tile> o_tile_idx = {blockIdx.z, blockIdx.y, seq_idx, 0};
-        tma::store_async(g.o, o_smem[0], o_tile_idx);
+    // wait v
+    kittens::wait(v_smem_arrived, kv_idx % 2);
+
+    // compute SV
+    warpgroup::mma_AB(o_reg, att_block_mma, v_smem[0]);
+    warpgroup::mma_async_wait();
+
+    // load V
+    if (threadIdx.x == 0) {
+      tma::expect_bytes(v_smem_arrived, sizeof(v_tile));
+      // coord<v_tile> v_tile_idx = {blockIdx.z, kv_head_idx, kv_idx + 1, 0};
+      // tma::load_async(v_smem[0], g.v, v_tile_idx, v_smem_arrived);
+      coord<v_tile_half> v_tile_idx_0 = {blockIdx.z, kv_head_idx,
+                                         kv_block_index[0], 0};
+      coord<v_tile_half> v_tile_idx_1 = {blockIdx.z, kv_head_idx,
+                                         kv_block_index[1], 0};
+      tma::load_async(v_smem_0[0], g.v, v_tile_idx_0, v_smem_arrived);
+      tma::load_async(v_smem_1[0], g.v, v_tile_idx_1, v_smem_arrived);
+    }
+  }
+
+  // last iter
+  {
+    int kv_idx = kv_blocks - 1;
+    // wait k
+    kittens::wait(k_smem_arrived, kv_idx % 2);
+
+    // compute QK^T
+    warpgroup::mm_ABt(att_block, q_smem[0], k_smem[0]);
+
+    copy(max_vec_last_scaled, max_vec);
+    if constexpr (D == 64) {
+      mul(max_vec_last_scaled, max_vec_last_scaled, 1.44269504089f * 0.125f);
+    } else {
+      mul(max_vec_last_scaled, max_vec_last_scaled,
+          1.44269504089f * 0.08838834764f);
     }
 
-    mul(max_vec_scaled,   max_vec_scaled, 0.69314718056f);
-    log(norm_vec, norm_vec);
-    add(norm_vec, norm_vec, max_vec_scaled);
+    warpgroup::mma_async_wait();
 
-    if constexpr (D == 64) { mul(norm_vec, norm_vec, -8.0f); }
-    else                   { mul(norm_vec, norm_vec, -11.313708499f); }
+    // exp
+    row_max(max_vec, att_block, max_vec);
 
-    warpgroup::store(l_smem[0], norm_vec);
-    __syncthreads();
-
-    if (threadIdx.x / 32 == 0) {
-        coord<l_col_vec> tile_idx = {blockIdx.z, blockIdx.y, 0, seq_idx};
-        tma::store_async(g.l, l_smem[0], tile_idx);
+    if constexpr (D == 64) {
+      mul(att_block, att_block, 1.44269504089f * 0.125f);
+      mul(max_vec_scaled, max_vec, 1.44269504089f * 0.125f);
+    } else {
+      mul(att_block, att_block, 1.44269504089f * 0.08838834764f);
+      mul(max_vec_scaled, max_vec, 1.44269504089f * 0.08838834764f);
     }
-    tma::store_async_wait();
+
+    sub_row(att_block, att_block, max_vec_scaled);
+    exp2(att_block, att_block);
+    sub(max_vec_last_scaled, max_vec_last_scaled, max_vec_scaled);
+    exp2(max_vec_last_scaled, max_vec_last_scaled);
+    mul(norm_vec, norm_vec, max_vec_last_scaled);
+    row_sum(norm_vec, att_block, norm_vec);
+    add(att_block, att_block, 0.f);
+    copy(att_block_mma, att_block);
+    mul_row(o_reg, o_reg, max_vec_last_scaled);
+
+    // wait v
+    kittens::wait(v_smem_arrived, kv_idx % 2);
+
+    // compute SV
+    warpgroup::mma_AB(o_reg, att_block_mma, v_smem[0]);
+    warpgroup::mma_async_wait();
+  }
+
+  div_row(o_reg, o_reg, norm_vec);
+  warpgroup::store(o_smem[0], o_reg);
+  __syncthreads();
+
+  // TK store_async internally calls syncwarp so we need to route on warp level
+  if (threadIdx.x / 32 == 0) {
+    coord<o_tile> o_tile_idx = {blockIdx.z, blockIdx.y, seq_idx, 0};
+    tma::store_async(g.o, o_smem[0], o_tile_idx);
+  }
+
+  mul(max_vec_scaled, max_vec_scaled, 0.69314718056f);
+  log(norm_vec, norm_vec);
+  add(norm_vec, norm_vec, max_vec_scaled);
+
+  if constexpr (D == 64) {
+    mul(norm_vec, norm_vec, -8.0f);
+  } else {
+    mul(norm_vec, norm_vec, -11.313708499f);
+  }
+
+  warpgroup::store(l_smem[0], norm_vec);
+  __syncthreads();
+
+  if (threadIdx.x / 32 == 0) {
+    coord<l_col_vec> tile_idx = {blockIdx.z, blockIdx.y, 0, seq_idx};
+    tma::store_async(g.l, l_smem[0], tile_idx);
+  }
+  tma::store_async_wait();
 }
 
-template<int D>
-__global__  __launch_bounds__(128, 4)
-void fwd_attend_ker(const __grid_constant__ fwd_globals<D> g) { // use block size of 64
-    extern __shared__ int __shm[]; 
-    tma_swizzle_allocator al((int*)&__shm[0]);
+template <int D>
+__global__ __launch_bounds__(128, 4) void fwd_attend_ker(
+    const __grid_constant__ fwd_globals<D> g) { // use block size of 64
+  extern __shared__ int __shm[];
+  tma_swizzle_allocator al((int *)&__shm[0]);
 
-    using K = fwd_attend_ker_tile_dims<D>;
+  using K = fwd_attend_ker_tile_dims<D>;
 
-    using q_tile    =         st_bf<64, K::tile_width>;
-    using k_tile    =         st_bf<64, K::tile_width>;
-    using v_tile    =         st_bf<64, K::tile_width>;
-    using l_col_vec = col_vec<st_fl<64, K::tile_width>>;
-    using o_tile    =         st_bf<64, K::tile_width>;
-    
-    q_tile    (&q_smem)[1] = al.allocate<q_tile, 1>();
+  using q_tile = st_bf<64, K::tile_width>;
+  using k_tile = st_bf<64, K::tile_width>;
+  using v_tile = st_bf<64, K::tile_width>;
+  using l_col_vec = col_vec<st_fl<64, K::tile_width>>;
+  using o_tile = st_bf<64, K::tile_width>;
 
-    k_tile    (&k_smem)[1]           = al.allocate<k_tile, 1          >();
+  q_tile(&q_smem)[1] = al.allocate<q_tile, 1>();
 
-    v_tile    (&v_smem)[1]           = al.allocate<v_tile, 1          >();
+  k_tile(&k_smem)[1] = al.allocate<k_tile, 1>();
 
-    l_col_vec (&l_smem)[1] = al.allocate<l_col_vec, 1>();
+  v_tile(&v_smem)[1] = al.allocate<v_tile, 1>();
 
-    auto      (*o_smem)                      = reinterpret_cast<o_tile(*)>(q_smem);
-    
-    int kv_head_idx = blockIdx.y / g.hr;
-    int seq_idx     = blockIdx.x; 
+  l_col_vec(&l_smem)[1] = al.allocate<l_col_vec, 1>();
 
-    int32_t* q2k_block_sparse_index_ptr = g.q2k_block_sparse_index + blockIdx.z * gridDim.y * gridDim.x * g.max_kv_blocks_per_q + blockIdx.y * gridDim.x * g.max_kv_blocks_per_q  + blockIdx.x * g.max_kv_blocks_per_q;
-    int32_t* q2k_block_sparse_num_ptr = g.q2k_block_sparse_num + blockIdx.z * gridDim.y * gridDim.x  + blockIdx.y * gridDim.x + blockIdx.x;
-    int32_t kv_blocks   = q2k_block_sparse_num_ptr[0];
-    __shared__ kittens::semaphore qsmem_semaphore, k_smem_arrived, v_smem_arrived;
+  auto(*o_smem) = reinterpret_cast<o_tile(*)>(q_smem);
+
+  int kv_head_idx = blockIdx.y / g.hr;
+  int seq_idx = blockIdx.x;
+
+  int32_t *q2k_block_sparse_index_ptr =
+      g.q2k_block_sparse_index +
+      blockIdx.z * gridDim.y * gridDim.x * g.max_kv_blocks_per_q +
+      blockIdx.y * gridDim.x * g.max_kv_blocks_per_q +
+      blockIdx.x * g.max_kv_blocks_per_q;
+  int32_t *q2k_block_sparse_num_ptr = g.q2k_block_sparse_num +
+                                      blockIdx.z * gridDim.y * gridDim.x +
+                                      blockIdx.y * gridDim.x + blockIdx.x;
+  int32_t kv_blocks = q2k_block_sparse_num_ptr[0];
+  __shared__ kittens::semaphore qsmem_semaphore, k_smem_arrived, v_smem_arrived;
+  if (threadIdx.x == 0) {
+    int32_t kv_block_index = q2k_block_sparse_index_ptr[0];
+
+    init_semaphore(qsmem_semaphore, 0, 1);
+    init_semaphore(k_smem_arrived, 0, 1);
+    init_semaphore(v_smem_arrived, 0, 1);
+
+    // preload q block
+    coord<q_tile> q_tile_idx = {blockIdx.z, blockIdx.y, seq_idx, 0};
+    tma::expect_bytes(qsmem_semaphore, sizeof(q_smem));
+    tma::load_async(q_smem[0], g.q, q_tile_idx, qsmem_semaphore);
+
+    // preload the zeroth block of kv
+    tma::expect_bytes(k_smem_arrived, sizeof(k_tile));
+    coord<k_tile> k_tile_idx = {blockIdx.z, kv_head_idx, kv_block_index, 0};
+    tma::load_async(k_smem[0], g.k, k_tile_idx, k_smem_arrived);
+
+    tma::expect_bytes(v_smem_arrived, sizeof(v_tile));
+    coord<v_tile> v_tile_idx = {blockIdx.z, kv_head_idx, kv_block_index, 0};
+    tma::load_async(v_smem[0], g.v, v_tile_idx, v_smem_arrived);
+  }
+  __syncthreads();
+
+  rt_fl<16, 64> att_block;
+  rt_bf<16, 64> att_block_mma;
+  rt_fl<16, K::tile_width> o_reg;
+
+  col_vec<rt_fl<16, 64>> max_vec, norm_vec, max_vec_last_scaled, max_vec_scaled;
+
+  neg_infty(max_vec);
+  zero(norm_vec);
+  zero(o_reg);
+
+  // wait for q block
+  kittens::wait(qsmem_semaphore, 0);
+
+  for (int kv_idx = 0; kv_idx < kv_blocks - 1; kv_idx++) {
+    // preload kv index
+    int32_t kv_block_index = q2k_block_sparse_index_ptr[kv_idx + 1];
+
+    // wait k
+    kittens::wait(k_smem_arrived, kv_idx % 2);
+
+    // compute QK^T
+    warpgroup::mm_ABt(att_block, q_smem[0], k_smem[0]);
+
+    copy(max_vec_last_scaled, max_vec);
+    if constexpr (D == 64) {
+      mul(max_vec_last_scaled, max_vec_last_scaled, 1.44269504089f * 0.125f);
+    } else {
+      mul(max_vec_last_scaled, max_vec_last_scaled,
+          1.44269504089f * 0.08838834764f);
+    }
+
+    warpgroup::mma_async_wait();
+
+    // load K
     if (threadIdx.x == 0) {
-        int32_t kv_block_index = q2k_block_sparse_index_ptr[0];
-        
-        init_semaphore(qsmem_semaphore, 0, 1);
-        init_semaphore(k_smem_arrived, 0, 1);
-        init_semaphore(v_smem_arrived, 0, 1);
-        
-        // preload q block
-        coord<q_tile> q_tile_idx = {blockIdx.z, blockIdx.y, seq_idx, 0};
-        tma::expect_bytes(qsmem_semaphore, sizeof(q_smem));
-        tma::load_async(q_smem[0], g.q, q_tile_idx, qsmem_semaphore);
-        
-        // preload the zeroth block of kv
-        tma::expect_bytes(k_smem_arrived, sizeof(k_tile));
-        coord<k_tile> k_tile_idx = {blockIdx.z, kv_head_idx, kv_block_index, 0};
-        tma::load_async(k_smem[0], g.k, k_tile_idx, k_smem_arrived);
-
-        tma::expect_bytes(v_smem_arrived, sizeof(v_tile));
-        coord<v_tile> v_tile_idx = {blockIdx.z, kv_head_idx, kv_block_index, 0};
-        tma::load_async(v_smem[0], g.v, v_tile_idx, v_smem_arrived);
-    }
-    __syncthreads(); 
-
-    rt_fl<16, 64>  att_block;
-    rt_bf<16, 64>  att_block_mma;
-    rt_fl<16, K::tile_width> o_reg;
-    
-    col_vec<rt_fl<16, 64>> max_vec, norm_vec, max_vec_last_scaled, max_vec_scaled;
-    
-    neg_infty(max_vec);
-    zero(norm_vec);
-    zero(o_reg);
-
-    // wait for q block
-    wait(qsmem_semaphore, 0);
-
-    for (int kv_idx = 0; kv_idx < kv_blocks - 1; kv_idx++) {
-        // preload kv index
-        int32_t kv_block_index = q2k_block_sparse_index_ptr[kv_idx + 1];
-        
-        // wait k
-        wait(k_smem_arrived, kv_idx % 2);
-
-        // compute QK^T
-        warpgroup::mm_ABt(att_block, q_smem[0], k_smem[0]);
-
-        copy(max_vec_last_scaled, max_vec);
-        if constexpr (D == 64) { mul(max_vec_last_scaled, max_vec_last_scaled, 1.44269504089f*0.125f); }
-        else                   { mul(max_vec_last_scaled, max_vec_last_scaled, 1.44269504089f*0.08838834764f); }
-        
-        warpgroup::mma_async_wait();
-
-        // load K
-        if (threadIdx.x == 0) {
-            tma::expect_bytes(k_smem_arrived, sizeof(k_tile));
-            coord<k_tile> k_tile_idx = {blockIdx.z, kv_head_idx, kv_block_index, 0};
-            tma::load_async(k_smem[0], g.k, k_tile_idx, k_smem_arrived);
-        }
-
-        // exp
-        row_max(max_vec, att_block, max_vec);
-            
-        if constexpr (D == 64) { 
-            mul(att_block, att_block,    1.44269504089f*0.125f); 
-            mul(max_vec_scaled, max_vec, 1.44269504089f*0.125f);
-        }
-        else                   { 
-            mul(att_block, att_block,    1.44269504089f*0.08838834764f); 
-            mul(max_vec_scaled, max_vec, 1.44269504089f*0.08838834764f);
-        }
-
-        sub_row(att_block, att_block, max_vec_scaled);
-        exp2(att_block, att_block);
-        sub(max_vec_last_scaled, max_vec_last_scaled, max_vec_scaled);
-        exp2(max_vec_last_scaled,       max_vec_last_scaled);
-        mul(norm_vec,            norm_vec,     max_vec_last_scaled);
-        row_sum(norm_vec,  att_block, norm_vec);
-        add(att_block, att_block, 0.f);
-        copy(att_block_mma, att_block);
-        mul_row(o_reg, o_reg, max_vec_last_scaled); 
-        
-        // wait v
-        wait(v_smem_arrived, kv_idx % 2);
-
-        // compute SV
-        warpgroup::mma_AB(o_reg, att_block_mma, v_smem[0]);
-        warpgroup::mma_async_wait();
-
-        // load V
-        if (threadIdx.x == 0) {
-            tma::expect_bytes(v_smem_arrived, sizeof(v_tile));
-            coord<v_tile> v_tile_idx = {blockIdx.z, kv_head_idx, kv_block_index, 0};
-            tma::load_async(v_smem[0], g.v, v_tile_idx, v_smem_arrived);
-        }
+      tma::expect_bytes(k_smem_arrived, sizeof(k_tile));
+      coord<k_tile> k_tile_idx = {blockIdx.z, kv_head_idx, kv_block_index, 0};
+      tma::load_async(k_smem[0], g.k, k_tile_idx, k_smem_arrived);
     }
 
-    // last iter
-    {
-        int kv_idx = kv_blocks - 1;
-        // wait k
-        wait(k_smem_arrived, kv_idx % 2);
+    // exp
+    row_max(max_vec, att_block, max_vec);
 
-        // compute QK^T
-        warpgroup::mm_ABt(att_block, q_smem[0], k_smem[0]);
-
-        copy(max_vec_last_scaled, max_vec);
-        if constexpr (D == 64) { mul(max_vec_last_scaled, max_vec_last_scaled, 1.44269504089f*0.125f); }
-        else                   { mul(max_vec_last_scaled, max_vec_last_scaled, 1.44269504089f*0.08838834764f); }
-        
-        warpgroup::mma_async_wait();      
-
-        // exp
-        row_max(max_vec, att_block, max_vec);
-            
-        if constexpr (D == 64) { 
-            mul(att_block, att_block,    1.44269504089f*0.125f); 
-            mul(max_vec_scaled, max_vec, 1.44269504089f*0.125f);
-        }
-        else                   { 
-            mul(att_block, att_block,    1.44269504089f*0.08838834764f); 
-            mul(max_vec_scaled, max_vec, 1.44269504089f*0.08838834764f);
-        }
-
-        sub_row(att_block, att_block, max_vec_scaled);
-        exp2(att_block, att_block);
-        sub(max_vec_last_scaled, max_vec_last_scaled, max_vec_scaled);
-        exp2(max_vec_last_scaled,       max_vec_last_scaled);
-        mul(norm_vec,            norm_vec,     max_vec_last_scaled);
-        row_sum(norm_vec,  att_block, norm_vec);
-        add(att_block, att_block, 0.f);
-        copy(att_block_mma, att_block); 
-        mul_row(o_reg, o_reg, max_vec_last_scaled); 
-        
-        // wait v
-        wait(v_smem_arrived, kv_idx % 2);
-
-        // compute SV
-        warpgroup::mma_AB(o_reg, att_block_mma, v_smem[0]);
-        warpgroup::mma_async_wait();
+    if constexpr (D == 64) {
+      mul(att_block, att_block, 1.44269504089f * 0.125f);
+      mul(max_vec_scaled, max_vec, 1.44269504089f * 0.125f);
+    } else {
+      mul(att_block, att_block, 1.44269504089f * 0.08838834764f);
+      mul(max_vec_scaled, max_vec, 1.44269504089f * 0.08838834764f);
     }
 
-    div_row(o_reg, o_reg, norm_vec);
-    warpgroup::store(o_smem[0], o_reg); 
-    __syncthreads();
+    sub_row(att_block, att_block, max_vec_scaled);
+    exp2(att_block, att_block);
+    sub(max_vec_last_scaled, max_vec_last_scaled, max_vec_scaled);
+    exp2(max_vec_last_scaled, max_vec_last_scaled);
+    mul(norm_vec, norm_vec, max_vec_last_scaled);
+    row_sum(norm_vec, att_block, norm_vec);
+    add(att_block, att_block, 0.f);
+    copy(att_block_mma, att_block);
+    mul_row(o_reg, o_reg, max_vec_last_scaled);
 
-    // TK store_async internally calls syncwarp so we need to route on warp level
-    if (threadIdx.x / 32 == 0) {
-        coord<o_tile> o_tile_idx = {blockIdx.z, blockIdx.y, seq_idx, 0};
-        tma::store_async(g.o, o_smem[0], o_tile_idx);
+    // wait v
+    kittens::wait(v_smem_arrived, kv_idx % 2);
+
+    // compute SV
+    warpgroup::mma_AB(o_reg, att_block_mma, v_smem[0]);
+    warpgroup::mma_async_wait();
+
+    // load V
+    if (threadIdx.x == 0) {
+      tma::expect_bytes(v_smem_arrived, sizeof(v_tile));
+      coord<v_tile> v_tile_idx = {blockIdx.z, kv_head_idx, kv_block_index, 0};
+      tma::load_async(v_smem[0], g.v, v_tile_idx, v_smem_arrived);
+    }
+  }
+
+  // last iter
+  {
+    int kv_idx = kv_blocks - 1;
+    // wait k
+    kittens::wait(k_smem_arrived, kv_idx % 2);
+
+    // compute QK^T
+    warpgroup::mm_ABt(att_block, q_smem[0], k_smem[0]);
+
+    copy(max_vec_last_scaled, max_vec);
+    if constexpr (D == 64) {
+      mul(max_vec_last_scaled, max_vec_last_scaled, 1.44269504089f * 0.125f);
+    } else {
+      mul(max_vec_last_scaled, max_vec_last_scaled,
+          1.44269504089f * 0.08838834764f);
     }
 
-    mul(max_vec_scaled,   max_vec_scaled, 0.69314718056f);
-    log(norm_vec, norm_vec);
-    add(norm_vec, norm_vec, max_vec_scaled);
+    warpgroup::mma_async_wait();
 
-    if constexpr (D == 64) { mul(norm_vec, norm_vec, -8.0f); }
-    else                   { mul(norm_vec, norm_vec, -11.313708499f); }
+    // exp
+    row_max(max_vec, att_block, max_vec);
 
-    warpgroup::store(l_smem[0], norm_vec);
-    __syncthreads();
-
-    if (threadIdx.x / 32 == 0) {
-        coord<l_col_vec> tile_idx = {blockIdx.z, blockIdx.y, 0, seq_idx};
-        tma::store_async(g.l, l_smem[0], tile_idx);
+    if constexpr (D == 64) {
+      mul(att_block, att_block, 1.44269504089f * 0.125f);
+      mul(max_vec_scaled, max_vec, 1.44269504089f * 0.125f);
+    } else {
+      mul(att_block, att_block, 1.44269504089f * 0.08838834764f);
+      mul(max_vec_scaled, max_vec, 1.44269504089f * 0.08838834764f);
     }
-    tma::store_async_wait();
+
+    sub_row(att_block, att_block, max_vec_scaled);
+    exp2(att_block, att_block);
+    sub(max_vec_last_scaled, max_vec_last_scaled, max_vec_scaled);
+    exp2(max_vec_last_scaled, max_vec_last_scaled);
+    mul(norm_vec, norm_vec, max_vec_last_scaled);
+    row_sum(norm_vec, att_block, norm_vec);
+    add(att_block, att_block, 0.f);
+    copy(att_block_mma, att_block);
+    mul_row(o_reg, o_reg, max_vec_last_scaled);
+
+    // wait v
+    kittens::wait(v_smem_arrived, kv_idx % 2);
+
+    // compute SV
+    warpgroup::mma_AB(o_reg, att_block_mma, v_smem[0]);
+    warpgroup::mma_async_wait();
+  }
+
+  div_row(o_reg, o_reg, norm_vec);
+  warpgroup::store(o_smem[0], o_reg);
+  __syncthreads();
+
+  // TK store_async internally calls syncwarp so we need to route on warp level
+  if (threadIdx.x / 32 == 0) {
+    coord<o_tile> o_tile_idx = {blockIdx.z, blockIdx.y, seq_idx, 0};
+    tma::store_async(g.o, o_smem[0], o_tile_idx);
+  }
+
+  mul(max_vec_scaled, max_vec_scaled, 0.69314718056f);
+  log(norm_vec, norm_vec);
+  add(norm_vec, norm_vec, max_vec_scaled);
+
+  if constexpr (D == 64) {
+    mul(norm_vec, norm_vec, -8.0f);
+  } else {
+    mul(norm_vec, norm_vec, -11.313708499f);
+  }
+
+  warpgroup::store(l_smem[0], norm_vec);
+  __syncthreads();
+
+  if (threadIdx.x / 32 == 0) {
+    coord<l_col_vec> tile_idx = {blockIdx.z, blockIdx.y, 0, seq_idx};
+    tma::store_async(g.l, l_smem[0], tile_idx);
+  }
+  tma::store_async_wait();
 }
 
 // ---------------------------------------------------------------------------------------------------
-// ----------------------------------- Backward preparation kernel -----------------------------------
+// ----------------------------------- Backward preparation kernel
+// -----------------------------------
 // ---------------------------------------------------------------------------------------------------
 
-template<int D>
-struct bwd_prep_globals {
-    using og_tile = st_bf<4*16, D>;
-    using o_tile  = st_bf<4*16, D>;
-    using d_tile  = col_vec<st_fl<4*16, D>>;
+template <int D> struct bwd_prep_globals {
+  using og_tile = st_bf<4 * 16, D>;
+  using o_tile = st_bf<4 * 16, D>;
+  using d_tile = col_vec<st_fl<4 * 16, D>>;
 
-    using og_gl = gl<bf16,  -1, -1, -1, -1, og_tile>;
-    using o_gl  = gl<bf16,  -1, -1, -1, -1, o_tile>;
-    using d_gl  = gl<float, -1, -1, -1, -1, d_tile>;
+  using og_gl = gl<bf16, -1, -1, -1, -1, og_tile>;
+  using o_gl = gl<bf16, -1, -1, -1, -1, o_tile>;
+  using d_gl = gl<float, -1, -1, -1, -1, d_tile>;
 
-    og_gl og;
-    o_gl  o;
-    d_gl  d;
+  og_gl og;
+  o_gl o;
+  d_gl d;
 };
 
-template<int D>
-__global__  __launch_bounds__(4*kittens::WARP_THREADS, (D == 64) ? 2 : 1)
-void bwd_attend_prep_ker(const __grid_constant__ bwd_prep_globals<D> g) {
-    extern __shared__ int __shm[]; 
-    tma_swizzle_allocator al((int*)&__shm[0]);
+template <int D>
+__global__ __launch_bounds__(
+    4 * kittens::WARP_THREADS,
+    (D == 64) ? 2 : 1) void bwd_attend_prep_ker(const __grid_constant__
+                                                    bwd_prep_globals<D>
+                                                        g) {
+  extern __shared__ int __shm[];
+  tma_swizzle_allocator al((int *)&__shm[0]);
 
-    int warpid = kittens::warpid();
+  int warpid = kittens::warpid();
 
-    using og_tile = st_bf<4*16, D>;
-    using o_tile  = st_bf<4*16, D>;
-    using d_tile  = col_vec<st_fl<4*16, D>>;
+  using og_tile = st_bf<4 * 16, D>;
+  using o_tile = st_bf<4 * 16, D>;
+  using d_tile = col_vec<st_fl<4 * 16, D>>;
 
-    og_tile (&og_smem)[4] = al.allocate<og_tile, 4>();
-    o_tile  (&o_smem) [4] = al.allocate<o_tile , 4>();
-    d_tile  (&d_smem) [4] = al.allocate<d_tile , 4>();
-    
-    rt_fl<4*16, D> og_reg, o_reg; 
-    col_vec<rt_fl<4*16, D>> d_reg;
+  og_tile(&og_smem)[4] = al.allocate<og_tile, 4>();
+  o_tile(&o_smem)[4] = al.allocate<o_tile, 4>();
+  d_tile(&d_smem)[4] = al.allocate<d_tile, 4>();
 
-    __shared__ kittens::semaphore smem_semaphore;
+  rt_fl<4 * 16, D> og_reg, o_reg;
+  col_vec<rt_fl<4 * 16, D>> d_reg;
 
+  __shared__ kittens::semaphore smem_semaphore;
+
+  if (threadIdx.x == 0) {
+    init_semaphore(smem_semaphore, 0, 1);
+    tma::expect_bytes(smem_semaphore, sizeof(og_smem[0]) * 4 * 2);
+  }
+  __syncthreads();
+
+  if (warpid == 0) {
+    for (int w = 0; w < 4; w++) {
+      coord<o_tile> tile_idx = {blockIdx.z, blockIdx.y, (blockIdx.x * 4) + w,
+                                0};
+      tma::load_async(o_smem[w], g.o, tile_idx, smem_semaphore);
+      tma::load_async(og_smem[w], g.og, tile_idx, smem_semaphore);
+    }
+  }
+
+  kittens::wait(smem_semaphore, 0);
+  load(o_reg, o_smem[warpid]);
+  load(og_reg, og_smem[warpid]);
+  mul(og_reg, og_reg, o_reg);
+  row_sum(d_reg, og_reg);
+  store(d_smem[warpid], d_reg);
+  __syncthreads();
+
+  if (warpid == 0) {
+    for (int w = 0; w < 4; w++) {
+      coord<d_tile> tile_idx = {blockIdx.z, blockIdx.y, 0,
+                                (blockIdx.x * 4) + w};
+      tma::store_async(g.d, d_smem[w], tile_idx);
+    }
+  }
+  tma::store_async_wait();
+}
+
+template <int D> struct bwd_attend_ker_tile_dims {};
+template <> struct bwd_attend_ker_tile_dims<64> {
+  constexpr static int tile_width = (64);
+  constexpr static int tile_h = (4 * 16);
+  constexpr static int tile_h_qo = (4 * 16);
+};
+template <> struct bwd_attend_ker_tile_dims<128> {
+  constexpr static int tile_width = (128);
+  constexpr static int tile_h = (4 * 16);
+  constexpr static int tile_h_qo = (4 * 16);
+};
+
+template <int D> struct bwd_globals {
+  using G = bwd_attend_ker_tile_dims<D>;
+
+  using q_tile = st_bf<G::tile_h_qo, G::tile_width>;
+  using k_tile = st_bf<G::tile_h, G::tile_width>;
+  using v_tile = st_bf<G::tile_h, G::tile_width>;
+  using og_tile = st_bf<G::tile_h_qo, G::tile_width>;
+  using qg_tile = st_fl<G::tile_h_qo, G::tile_width>;
+  using kg_tile = st_fl<G::tile_h, G::tile_width>;
+  using vg_tile = st_fl<G::tile_h, G::tile_width>;
+  using l_tile = row_vec<st_fl<G::tile_h_qo, G::tile_h>>;
+  using d_tile = row_vec<st_fl<G::tile_h_qo, G::tile_h>>;
+
+  using q_gl = gl<bf16, -1, -1, -1, -1, q_tile>;
+  using k_gl = gl<bf16, -1, -1, -1, -1, k_tile>;
+  using v_gl = gl<bf16, -1, -1, -1, -1, v_tile>;
+
+  using og_gl = gl<bf16, -1, -1, -1, -1, og_tile>;
+
+  using qg_gl = gl<float, -1, -1, -1, -1, qg_tile>;
+  using kg_gl = gl<float, -1, -1, -1, -1, kg_tile>;
+  using vg_gl = gl<float, -1, -1, -1, -1, vg_tile>;
+
+  using l_gl = gl<float, -1, -1, -1, -1, l_tile>;
+  using d_gl = gl<float, -1, -1, -1, -1, d_tile>;
+
+  q_gl q;
+  k_gl k;
+  v_gl v;
+  og_gl og;
+  qg_gl qg;
+  kg_gl kg;
+  vg_gl vg;
+  l_gl l;
+  d_gl d;
+
+  const int N;
+  const int hr;
+  const int max_q_blocks_per_kv;
+
+  int32_t *__restrict__ k2q_block_sparse_index;
+  int32_t *__restrict__ k2q_block_sparse_num;
+};
+
+__device__ static inline void stream_tile(auto &reg_tile, auto &smem_vec,
+                                          int tic) {
+#pragma unroll
+  for (int i = 0; i < 4; i++) {
+    int base_col = 16 * i + 2 * (kittens::laneid() % 4);
+    reg_tile.tiles[0][i].data[0] = *(float2 *)&smem_vec[tic][base_col + 0];
+    reg_tile.tiles[0][i].data[1] = *(float2 *)&smem_vec[tic][base_col + 0];
+    reg_tile.tiles[0][i].data[2] = *(float2 *)&smem_vec[tic][base_col + 8];
+    reg_tile.tiles[0][i].data[3] = *(float2 *)&smem_vec[tic][base_col + 8];
+  }
+}
+
+__device__ static inline void stream_sub_tile(auto &reg_tile, auto &smem_vec,
+                                              int tic) {
+#pragma unroll
+  for (int i = 0; i < 4; i++) {
+    int base_col = 16 * i + 2 * (laneid() % 4);
+    reg_tile.tiles[0][i].data[0] = base_ops::sub::template op<float2>(
+        reg_tile.tiles[0][i].data[0], *(float2 *)&smem_vec[tic][base_col + 0]);
+    reg_tile.tiles[0][i].data[1] = base_ops::sub::template op<float2>(
+        reg_tile.tiles[0][i].data[1], *(float2 *)&smem_vec[tic][base_col + 0]);
+    reg_tile.tiles[0][i].data[2] = base_ops::sub::template op<float2>(
+        reg_tile.tiles[0][i].data[2], *(float2 *)&smem_vec[tic][base_col + 8]);
+    reg_tile.tiles[0][i].data[3] = base_ops::sub::template op<float2>(
+        reg_tile.tiles[0][i].data[3], *(float2 *)&smem_vec[tic][base_col + 8]);
+  }
+}
+
+template <int D>
+__global__ __launch_bounds__(128, (D == 64) ? 3 : 2) void bwd_attend_ker(
+    const __grid_constant__ bwd_globals<D> g) {
+  extern __shared__ int __shm[];
+  tma_swizzle_allocator al((int *)&__shm[0]);
+
+  const int N = g.N, hr = g.hr;
+  using G = bwd_attend_ker_tile_dims<D>;
+
+  using kg_tile = st_fl<G::tile_h, G::tile_width>;
+  using vg_tile = st_fl<G::tile_h, G::tile_width>;
+  using k_tile = st_bf<G::tile_h, G::tile_width>;
+  using v_tile = st_bf<G::tile_h, G::tile_width>;
+  using q_tile = st_bf<G::tile_h_qo, G::tile_width>;
+  using og_tile = st_bf<G::tile_h_qo, G::tile_width>;
+  using qg_tile = st_fl<G::tile_h_qo, G::tile_width>;
+  using l_tile = row_vec<st_fl<G::tile_h_qo, G::tile_h>>;
+  using d_tile = row_vec<st_fl<G::tile_h_qo, G::tile_h>>;
+  using attn_tile = st_bf<G::tile_h_qo, G::tile_h>;
+
+  k_tile(&k_smem)[1] = al.allocate<k_tile, 1>();
+  v_tile(&v_smem)[1] = al.allocate<v_tile, 1>();
+
+  q_tile(&q_smem)[1] = al.allocate<q_tile, 1>();
+  og_tile(&og_smem)[1] = al.allocate<og_tile, 1>();
+  qg_tile(&qg_smem) = al.allocate<qg_tile>();
+
+  l_tile(&l_smem)[1] = al.allocate<l_tile, 1>();
+  d_tile(&d_smem)[1] = al.allocate<d_tile, 1>();
+  kg_tile(*kg_smem) = reinterpret_cast<kg_tile *>(&k_smem[0].data[0]);
+  vg_tile(*vg_smem) = reinterpret_cast<vg_tile *>(&q_smem[0].data[0]);
+
+  attn_tile(&ds_smem_t)[1] = al.allocate<attn_tile, 1>();
+
+  const int warpid = kittens::warpid();
+  const int warpgroupid = warpid / kittens::WARPGROUP_WARPS;
+  const int kv_head_idx = (blockIdx.y) / hr;
+
+  int32_t *__restrict__ k2q_block_sparse_index_ptr =
+      g.k2q_block_sparse_index +
+      blockIdx.z * gridDim.y * gridDim.x * g.max_q_blocks_per_kv +
+      blockIdx.y * gridDim.x * g.max_q_blocks_per_kv +
+      blockIdx.x * g.max_q_blocks_per_kv;
+  int32_t *__restrict__ k2q_block_sparse_num_ptr =
+      g.k2q_block_sparse_num + blockIdx.z * gridDim.y * gridDim.x +
+      blockIdx.y * gridDim.x + blockIdx.x;
+  const int qo_blocks = *k2q_block_sparse_num_ptr;
+
+  if (qo_blocks <= 0) {
+    return;
+  }
+
+  __shared__ kittens::semaphore kv_b, q_b[1], o_b[1], vec_b[1];
+
+  int32_t store_qg_block_index;
+  int32_t load_q_block_index;
+
+  if (threadIdx.x == 0) {
+    load_q_block_index = k2q_block_sparse_index_ptr[0];
+
+    init_semaphore(kv_b, 0, 1);
+
+    init_semaphore(q_b[0], 0, 1);
+    init_semaphore(o_b[0], 0, 1);
+    init_semaphore(vec_b[0], 0, 1);
+
+    // preload KV
+    tma::expect_bytes(kv_b, sizeof(k_smem[0]) + sizeof(v_smem[0]));
+    coord<k_tile> tile_idx_kv = {blockIdx.z, kv_head_idx, blockIdx.x, 0};
+    tma::load_async(k_smem[0], g.k, tile_idx_kv, kv_b);
+    tma::load_async(v_smem[0], g.v, tile_idx_kv, kv_b);
+
+    // preload og, vec and q
+    coord<q_tile> tile_idx_qo = {blockIdx.z, blockIdx.y, load_q_block_index, 0};
+    coord<l_tile> vec_idx = {blockIdx.z, blockIdx.y, 0, load_q_block_index};
+
+    tma::expect_bytes(o_b[0], sizeof(og_smem[0]));
+    tma::load_async(og_smem[0], g.og, tile_idx_qo, o_b[0]);
+
+    tma::expect_bytes(vec_b[0], sizeof(l_smem[0]) + sizeof(d_smem[0]));
+    tma::load_async(l_smem[0], g.l, vec_idx, vec_b[0]);
+    tma::load_async(d_smem[0], g.d, vec_idx, vec_b[0]);
+
+    tma::expect_bytes(q_b[0], sizeof(q_smem[0]));
+    tma::load_async(q_smem[0], g.q, tile_idx_qo, q_b[0]);
+  }
+  __syncthreads();
+
+  rt_fl<16, G::tile_width> kg_reg, vg_reg;
+
+  row_vec<rt_fl<16, 64>> row_reg;
+
+  rt_fl<16, 64> s_block_t, p_block_t;
+  rt_fl<16, 64> ds_block_t, dp_block_t;
+  rt_bf<16, 64> ds_block_t_mma, p_block_t_mma;
+
+  zero(kg_reg);
+  zero(vg_reg);
+
+  // wait for kv
+  kittens::wait(kv_b, 0);
+
+  for (int qo_idx = 0; qo_idx < qo_blocks - 1; qo_idx++) {
+    // preload q index
+    store_qg_block_index = load_q_block_index;
+    load_q_block_index = k2q_block_sparse_index_ptr[qo_idx + 1];
+
+    kittens::wait(o_b[0], qo_idx % 2);
+    warpgroup::mm_ABt(dp_block_t, v_smem[0], og_smem[0]); // dP^T = VdO^T
+    warpgroup::mma_commit_group();                        // ! do not wait
+
+    kittens::wait(vec_b[0], qo_idx % 2);
+    stream_tile(s_block_t, l_smem, 0);
+    kittens::wait(q_b[0], qo_idx % 2);
+    warpgroup::mma_ABt(s_block_t, k_smem[0], q_smem[0]); // S^T = KQ^T - l
+    warpgroup::mma_commit_group();
+    warpgroup::mma_async_wait();
+
+    if constexpr (D == 64) {
+      mul(s_block_t, s_block_t, 1.44269504089f * 0.125f);
+    } else {
+      mul(s_block_t, s_block_t, 1.44269504089f * 0.08838834764f);
+    }
+
+    exp2(s_block_t, s_block_t); // P_i
+    copy(p_block_t, s_block_t);
+    copy(p_block_t_mma, s_block_t);
+    stream_sub_tile(dp_block_t, d_smem, 0); // dP - D
+    mul(ds_block_t, p_block_t, dp_block_t); // dS = P \odot (dP - D)
+
+    if constexpr (D == 64) {
+      mul(ds_block_t, ds_block_t, 0.125f);
+    } else {
+      mul(ds_block_t, ds_block_t, 0.08838834764f);
+    }
+
+    // load vec
     if (threadIdx.x == 0) {
-        init_semaphore(smem_semaphore, 0, 1);
-        tma::expect_bytes(smem_semaphore, sizeof(og_smem[0]) * 4 * 2);
-    }
-    __syncthreads();
-
-    if (warpid == 0) {
-        for (int w = 0; w < 4; w++) {
-            coord<o_tile> tile_idx = {blockIdx.z, blockIdx.y, (blockIdx.x * 4) + w, 0};
-            tma::load_async(o_smem[w],  g.o,  tile_idx, smem_semaphore);
-            tma::load_async(og_smem[w], g.og, tile_idx, smem_semaphore);
-        }
+      coord<l_tile> vec_idx = {blockIdx.z, blockIdx.y, 0, load_q_block_index};
+      tma::expect_bytes(vec_b[0], sizeof(l_smem[0]) + sizeof(d_smem[0]));
+      tma::load_async(l_smem[0], g.l, vec_idx, vec_b[0]);
+      tma::load_async(d_smem[0], g.d, vec_idx, vec_b[0]);
     }
 
-    wait(smem_semaphore, 0);
-    load(o_reg, o_smem[warpid]);
-    load(og_reg, og_smem[warpid]);
-    mul(og_reg, og_reg, o_reg);
-    row_sum(d_reg, og_reg);
-    store(d_smem[warpid], d_reg);
-    __syncthreads(); 
+    warpgroup::mma_AB(vg_reg, p_block_t_mma, og_smem[0]); // dV += P^TdO
+    warpgroup::mma_commit_group();
+    copy(ds_block_t_mma, ds_block_t);
+    warpgroup::store(ds_smem_t[0], ds_block_t);
+    warpgroup::mma_async_wait();
 
-    if (warpid == 0) {
-        for (int w = 0; w < 4; w++) {
-            coord<d_tile> tile_idx = {blockIdx.z, blockIdx.y, 0, (blockIdx.x * 4) + w};
-            tma::store_async(g.d, d_smem[w], tile_idx);
-        }
+    // load og
+    if (threadIdx.x == 0) {
+      coord<q_tile> tile_idx = {blockIdx.z, blockIdx.y, load_q_block_index, 0};
+      tma::expect_bytes(o_b[0], sizeof(og_smem[0]));
+      tma::load_async(og_smem[0], g.og, tile_idx, o_b[0]);
     }
+
+    warpgroup::mma_AB(kg_reg, ds_block_t_mma, q_smem[0]); // dK += dS^TQ
+    warpgroup::mma_commit_group();
+    warpgroup::mma_async_wait();
+
+    // load q
+    if (threadIdx.x == 0) {
+      coord<q_tile> q_tile_idx = {blockIdx.z, blockIdx.y, load_q_block_index,
+                                  0};
+      tma::expect_bytes(q_b[0], sizeof(q_smem[0]));
+      tma::load_async(q_smem[0], g.q, q_tile_idx, q_b[0]);
+    }
+
+    rt_fl<16, G::tile_width> qg_reg;
+    __syncthreads(); // wait for sd_smem shared memory write
+    warpgroup::mm_AtB(qg_reg, ds_smem_t[0], k_smem[0]); // delat dQ = dSK
+    warpgroup::mma_commit_group();
     tma::store_async_wait();
-}
-
-template<int D> struct bwd_attend_ker_tile_dims {};
-template<> struct bwd_attend_ker_tile_dims<64> {
-    constexpr static int tile_width = (64);
-    constexpr static int tile_h     = (4*16);
-    constexpr static int tile_h_qo  = (4*16);
-};
-template<> struct bwd_attend_ker_tile_dims<128> {
-    constexpr static int tile_width = (128);
-    constexpr static int tile_h     = (4*16);
-    constexpr static int tile_h_qo  = (4*16);
-};
-
-template<int D>
-struct bwd_globals {
-    using G = bwd_attend_ker_tile_dims<D>;
-
-    using q_tile  =         st_bf<G::tile_h_qo, G::tile_width>;
-    using k_tile  =         st_bf<G::tile_h,    G::tile_width>;
-    using v_tile  =         st_bf<G::tile_h,    G::tile_width>;
-    using og_tile =         st_bf<G::tile_h_qo, G::tile_width>;
-    using qg_tile =         st_fl<G::tile_h_qo, G::tile_width>;
-    using kg_tile =         st_fl<G::tile_h,    G::tile_width>;
-    using vg_tile =         st_fl<G::tile_h,    G::tile_width>;
-    using l_tile  = row_vec<st_fl<G::tile_h_qo, G::tile_h>>;
-    using d_tile  = row_vec<st_fl<G::tile_h_qo, G::tile_h>>;
-
-    using q_gl  = gl<bf16,  -1, -1, -1, -1, q_tile>;
-    using k_gl  = gl<bf16,  -1, -1, -1, -1, k_tile>;
-    using v_gl  = gl<bf16,  -1, -1, -1, -1, v_tile>;
-
-    using og_gl = gl<bf16,  -1, -1, -1, -1, og_tile>;
-
-    using qg_gl = gl<float, -1, -1, -1, -1, qg_tile>;
-    using kg_gl = gl<float, -1, -1, -1, -1, kg_tile>;
-    using vg_gl = gl<float, -1, -1, -1, -1, vg_tile>;
-
-    using l_gl  = gl<float, -1, -1, -1, -1, l_tile>;
-    using d_gl  = gl<float, -1, -1, -1, -1, d_tile>; 
-
-    q_gl  q;
-    k_gl  k;
-    v_gl  v;
-    og_gl og;
-    qg_gl qg;
-    kg_gl kg;
-    vg_gl vg;
-    l_gl  l;
-    d_gl  d;
-
-    const int N;
-    const int hr;
-    const int max_q_blocks_per_kv;
-
-    int32_t *__restrict__ k2q_block_sparse_index;
-    int32_t *__restrict__ k2q_block_sparse_num;
-};
-
-__device__ static inline void
-stream_tile(auto &reg_tile, auto &smem_vec, int tic) {
-    #pragma unroll
-    for(int i = 0; i < 4; i++) {
-        int base_col = 16*i + 2*(kittens::laneid()%4);
-        reg_tile.tiles[0][i].data[0] = *(float2*)&smem_vec[tic][base_col + 0];
-        reg_tile.tiles[0][i].data[1] = *(float2*)&smem_vec[tic][base_col + 0];
-        reg_tile.tiles[0][i].data[2] = *(float2*)&smem_vec[tic][base_col + 8];
-        reg_tile.tiles[0][i].data[3] = *(float2*)&smem_vec[tic][base_col + 8];
-    }
-}
-
-__device__ static inline void
-stream_sub_tile(auto &reg_tile, auto &smem_vec, int tic) {
-    #pragma unroll
-    for(int i = 0; i < 4; i++) {
-        int base_col = 16*i + 2*(laneid()%4);
-        reg_tile.tiles[0][i].data[0] = base_ops::sub::template op<float2>(reg_tile.tiles[0][i].data[0], *(float2*)&smem_vec[tic][base_col + 0]);
-        reg_tile.tiles[0][i].data[1] = base_ops::sub::template op<float2>(reg_tile.tiles[0][i].data[1], *(float2*)&smem_vec[tic][base_col + 0]);
-        reg_tile.tiles[0][i].data[2] = base_ops::sub::template op<float2>(reg_tile.tiles[0][i].data[2], *(float2*)&smem_vec[tic][base_col + 8]);
-        reg_tile.tiles[0][i].data[3] = base_ops::sub::template op<float2>(reg_tile.tiles[0][i].data[3], *(float2*)&smem_vec[tic][base_col + 8]);
-    }
-}
-
-template<int D>
-__global__ __launch_bounds__(128, (D == 64)? 3 : 2)
-void bwd_attend_ker(const __grid_constant__ bwd_globals<D> g) {
-    extern __shared__ int __shm[];
-    tma_swizzle_allocator al((int*)&__shm[0]);
-
-    const int N = g.N, hr = g.hr;
-    using G = bwd_attend_ker_tile_dims<D>;
-    
-    using kg_tile   = st_fl<G::tile_h, G::tile_width>;
-    using vg_tile   = st_fl<G::tile_h, G::tile_width>;
-    using k_tile    = st_bf<G::tile_h, G::tile_width>;
-    using v_tile    = st_bf<G::tile_h, G::tile_width>;
-    using q_tile    = st_bf<G::tile_h_qo, G::tile_width>;
-    using og_tile   = st_bf<G::tile_h_qo, G::tile_width>;
-    using qg_tile   = st_fl<G::tile_h_qo, G::tile_width>;
-    using l_tile    = row_vec<st_fl<G::tile_h_qo, G::tile_h>>;
-    using d_tile    = row_vec<st_fl<G::tile_h_qo, G::tile_h>>;
-    using attn_tile = st_bf<G::tile_h_qo, G::tile_h>; 
-
-    k_tile  (&k_smem) [1] = al.allocate<k_tile, 1>();
-    v_tile  (&v_smem) [1] = al.allocate<v_tile, 1>();
-
-    q_tile  (&q_smem) [1] = al.allocate<q_tile, 1>(); 
-    og_tile (&og_smem)[1] = al.allocate<og_tile, 1>(); 
-    qg_tile (&qg_smem)    = al.allocate<qg_tile>();
-
-    l_tile   (&l_smem)[1] = al.allocate<l_tile, 1>();
-    d_tile   (&d_smem)[1] = al.allocate<d_tile, 1>();
-    kg_tile (*kg_smem)    = reinterpret_cast<kg_tile*>(&k_smem[0].data[0]); 
-    vg_tile (*vg_smem)    = reinterpret_cast<vg_tile*>(&q_smem[0].data[0]); 
-
-    attn_tile (&ds_smem_t)[1] = al.allocate<attn_tile, 1>();
-
-    const int warpid      = kittens::warpid();
-    const int warpgroupid = warpid/kittens::WARPGROUP_WARPS;
-    const int kv_head_idx = (blockIdx.y) / hr; 
-
-
-    int32_t *__restrict__ k2q_block_sparse_index_ptr = g.k2q_block_sparse_index + blockIdx.z * gridDim.y * gridDim.x * g.max_q_blocks_per_kv + blockIdx.y * gridDim.x * g.max_q_blocks_per_kv  + blockIdx.x * g.max_q_blocks_per_kv;
-    int32_t *__restrict__ k2q_block_sparse_num_ptr   = g.k2q_block_sparse_num   + blockIdx.z * gridDim.y * gridDim.x + blockIdx.y * gridDim.x + blockIdx.x;
-    const int qo_blocks = *k2q_block_sparse_num_ptr;
-
-    if (qo_blocks <= 0) {
-        return;
-    }
-
-    __shared__ kittens::semaphore kv_b, q_b[1], o_b[1], vec_b[1];
-
-    int32_t store_qg_block_index;
-    int32_t load_q_block_index;
-
-    if (threadIdx.x == 0) {
-        load_q_block_index = k2q_block_sparse_index_ptr[0];
-
-        init_semaphore(kv_b,  0, 1);
-
-        init_semaphore(q_b[0],   0, 1);
-        init_semaphore(o_b[0],   0, 1); 
-        init_semaphore(vec_b[0], 0, 1);
-        
-        // preload KV
-        tma::expect_bytes(kv_b, sizeof(k_smem[0]) + sizeof(v_smem[0]));
-        coord<k_tile> tile_idx_kv = {blockIdx.z, kv_head_idx, blockIdx.x, 0};
-        tma::load_async(k_smem[0], g.k, tile_idx_kv, kv_b);
-        tma::load_async(v_smem[0], g.v, tile_idx_kv, kv_b);
-        
-        // preload og, vec and q
-        coord<q_tile> tile_idx_qo = {blockIdx.z, blockIdx.y, load_q_block_index, 0};
-        coord<l_tile> vec_idx = {blockIdx.z, blockIdx.y, 0, load_q_block_index};
-
-        tma::expect_bytes(o_b[0],   sizeof(og_smem[0]));
-        tma::load_async(og_smem[0], g.og, tile_idx_qo, o_b[0]);
-
-        tma::expect_bytes(vec_b[0], sizeof(l_smem[0]) + sizeof(d_smem[0]));
-        tma::load_async(l_smem[0], g.l, vec_idx, vec_b[0]);
-        tma::load_async(d_smem[0], g.d, vec_idx, vec_b[0]);
-
-        tma::expect_bytes(q_b[0],   sizeof(q_smem[0]));
-        tma::load_async(q_smem[0],  g.q,  tile_idx_qo, q_b[0]);
-    }
+    warpgroup::mma_async_wait();
+    // store qg to shared memory
+    warpgroup::store(qg_smem, qg_reg);
     __syncthreads();
 
-    rt_fl<16, G::tile_width> kg_reg, vg_reg;
-    
-    row_vec<rt_fl<16, 64>> row_reg; 
-
-    rt_fl<16, 64> s_block_t,  p_block_t; 
-    rt_fl<16, 64> ds_block_t, dp_block_t; 
-    rt_bf<16, 64> ds_block_t_mma, p_block_t_mma;
-
-    zero(kg_reg);
-    zero(vg_reg);
-    
-    // wait for kv
-    wait(kv_b, 0);
-
-    for (int qo_idx = 0; qo_idx < qo_blocks - 1; qo_idx++) {
-        // preload q index
-        store_qg_block_index = load_q_block_index;
-        load_q_block_index = k2q_block_sparse_index_ptr[qo_idx + 1];
-
-        wait(o_b[0], qo_idx % 2);
-        warpgroup::mm_ABt(dp_block_t, v_smem[0], og_smem[0]); // dP^T = VdO^T
-        warpgroup::mma_commit_group(); // ! do not wait
-      
-        wait(vec_b[0], qo_idx % 2);
-        stream_tile(s_block_t, l_smem, 0);
-        wait(q_b[0], qo_idx % 2);
-        warpgroup::mma_ABt(s_block_t, k_smem[0], q_smem[0]); // S^T = KQ^T - l
-        warpgroup::mma_commit_group();
-        warpgroup::mma_async_wait();
-
-        if constexpr (D == 64) { mul(s_block_t, s_block_t, 1.44269504089f*0.125f); }
-        else                   { mul(s_block_t, s_block_t, 1.44269504089f*0.08838834764f); }
-    
-        exp2(s_block_t, s_block_t); // P_i
-        copy(p_block_t, s_block_t);
-        copy(p_block_t_mma, s_block_t);
-        stream_sub_tile(dp_block_t, d_smem, 0); // dP - D
-        mul(ds_block_t, p_block_t, dp_block_t); // dS = P \odot (dP - D)
-
-        if constexpr (D == 64) { mul(ds_block_t, ds_block_t, 0.125f); }
-        else                   { mul(ds_block_t, ds_block_t, 0.08838834764f); }
-
-        // load vec
-        if (threadIdx.x == 0) {
-            coord<l_tile> vec_idx = {blockIdx.z, blockIdx.y, 0, load_q_block_index};
-            tma::expect_bytes(vec_b[0], sizeof(l_smem[0]) + sizeof(d_smem[0]));
-            tma::load_async(l_smem[0], g.l, vec_idx, vec_b[0]);
-            tma::load_async(d_smem[0], g.d, vec_idx, vec_b[0]);
-        }
-    
-        warpgroup::mma_AB(vg_reg, p_block_t_mma, og_smem[0]); // dV += P^TdO
-        warpgroup::mma_commit_group();
-        copy(ds_block_t_mma, ds_block_t);
-        warpgroup::store(ds_smem_t[0], ds_block_t);
-        warpgroup::mma_async_wait();
-
-        // load og
-        if (threadIdx.x == 0) {
-            coord<q_tile> tile_idx = {blockIdx.z, blockIdx.y, load_q_block_index, 0};
-            tma::expect_bytes(o_b[0],   sizeof(og_smem[0]));
-            tma::load_async(og_smem[0], g.og, tile_idx, o_b[0]);
-        }
-
-        warpgroup::mma_AB(kg_reg, ds_block_t_mma, q_smem[0]); // dK += dS^TQ
-        warpgroup::mma_commit_group();
-        warpgroup::mma_async_wait();
-
-        // load q
-        if (threadIdx.x == 0) {
-            coord<q_tile> q_tile_idx = {blockIdx.z, blockIdx.y, load_q_block_index, 0};
-            tma::expect_bytes(q_b[0], sizeof(q_smem[0]));
-            tma::load_async(q_smem[0], g.q, q_tile_idx, q_b[0]);
-        }
-
-        rt_fl<16, G::tile_width> qg_reg; 
-        __syncthreads(); // wait for sd_smem shared memory write
-        warpgroup::mm_AtB(qg_reg, ds_smem_t[0], k_smem[0]); //delat dQ = dSK
-        warpgroup::mma_commit_group();
-        tma::store_async_wait();
-        warpgroup::mma_async_wait();
-        // store qg to shared memory
-        warpgroup::store(qg_smem, qg_reg);
-        __syncthreads();
-
-        // store and add dQ to global memory
-        if (threadIdx.x / 32 == 0) {
-            coord<qg_tile> tile_idx = {blockIdx.z, blockIdx.y, store_qg_block_index, 0};
-            tma::store_add_async(g.qg, qg_smem, tile_idx);
-        }
-    }
-
-    // last iter
-    {
-        int qo_idx = qo_blocks - 1;
-
-        store_qg_block_index = load_q_block_index;
-
-        wait(o_b[0], qo_idx % 2);
-        warpgroup::mm_ABt(dp_block_t, v_smem[0], og_smem[0]); // dP = dOV^T
-        warpgroup::mma_commit_group(); // ! do not wait
-      
-        wait(vec_b[0], qo_idx % 2);
-        stream_tile(s_block_t, l_smem, 0);
-        wait(q_b[0], qo_idx % 2);
-        warpgroup::mma_ABt(s_block_t, k_smem[0], q_smem[0]); // S = QK^T - l
-        warpgroup::mma_commit_group();
-        warpgroup::mma_async_wait();
-
-        if constexpr (D == 64) { mul(s_block_t, s_block_t, 1.44269504089f*0.125f); }
-        else                   { mul(s_block_t, s_block_t, 1.44269504089f*0.08838834764f); }
-    
-        exp2(s_block_t, s_block_t); // P_i
-        copy(p_block_t, s_block_t);
-        copy(p_block_t_mma, s_block_t);
-        stream_sub_tile(dp_block_t, d_smem, 0); // dP - D
-        mul(ds_block_t, p_block_t, dp_block_t); // dS = P \odot (dP - D)
-
-        if constexpr (D == 64) { mul(ds_block_t, ds_block_t, 0.125f); }
-        else                   { mul(ds_block_t, ds_block_t, 0.08838834764f); }
-
-        warpgroup::mma_AB(vg_reg, p_block_t_mma, og_smem[0]); // dV += P^TdO
-        warpgroup::mma_commit_group();
-        copy(ds_block_t_mma, ds_block_t);
-        warpgroup::store(ds_smem_t[0], ds_block_t);
-        warpgroup::mma_async_wait();
-
-        warpgroup::mma_AB(kg_reg, ds_block_t_mma, q_smem[0]); // dK += dS^TQ
-        warpgroup::mma_commit_group();
-        warpgroup::mma_async_wait();
-
-        rt_fl<16, G::tile_width> qg_reg; 
-        __syncthreads(); // wait for sd_smem shared memory write
-        warpgroup::mm_AtB(qg_reg, ds_smem_t[0], k_smem[0]); //delat dQ = dSK
-        warpgroup::mma_commit_group();
-        tma::store_async_wait();
-        warpgroup::mma_async_wait();
-        // store qg to shared memory
-        warpgroup::store(qg_smem, qg_reg);
-        __syncthreads();
-
-        // store and add dQ to global memory
-        if (threadIdx.x / 32 == 0) {
-            coord<qg_tile> tile_idx = {blockIdx.z, blockIdx.y, store_qg_block_index, 0};
-            tma::store_add_async(g.qg, qg_smem, tile_idx);
-        }
-    }
-
-    // store kq and vq
-
-    // ! the following two line seems unnecessary.
-    tma::store_async_wait(); // ensure qg is finished
-    __syncthreads();
-
-    warpgroup::store(kg_smem[0], kg_reg);
-    __syncthreads();
+    // store and add dQ to global memory
     if (threadIdx.x / 32 == 0) {
-        coord<kg_tile> tile_idx = {blockIdx.z, kv_head_idx, blockIdx.x, 0};
-        tma::store_add_async(g.kg, kg_smem[0], tile_idx);
-        tma::store_commit_group();
+      coord<qg_tile> tile_idx = {blockIdx.z, blockIdx.y, store_qg_block_index,
+                                 0};
+      tma::store_add_async(g.qg, qg_smem, tile_idx);
+    }
+  }
+
+  // last iter
+  {
+    int qo_idx = qo_blocks - 1;
+
+    store_qg_block_index = load_q_block_index;
+
+    kittens::wait(o_b[0], qo_idx % 2);
+    warpgroup::mm_ABt(dp_block_t, v_smem[0], og_smem[0]); // dP = dOV^T
+    warpgroup::mma_commit_group();                        // ! do not wait
+
+    kittens::wait(vec_b[0], qo_idx % 2);
+    stream_tile(s_block_t, l_smem, 0);
+    kittens::wait(q_b[0], qo_idx % 2);
+    warpgroup::mma_ABt(s_block_t, k_smem[0], q_smem[0]); // S = QK^T - l
+    warpgroup::mma_commit_group();
+    warpgroup::mma_async_wait();
+
+    if constexpr (D == 64) {
+      mul(s_block_t, s_block_t, 1.44269504089f * 0.125f);
+    } else {
+      mul(s_block_t, s_block_t, 1.44269504089f * 0.08838834764f);
     }
 
-    warpgroup::store(vg_smem[0], vg_reg);
-    __syncthreads();
-    if (kittens::warpid() % 4 == 0) {
-        coord<vg_tile> tile_idx = {blockIdx.z, kv_head_idx, blockIdx.x, 0};
-        tma::store_add_async(g.vg, vg_smem[0], tile_idx);
-        tma::store_commit_group();
+    exp2(s_block_t, s_block_t); // P_i
+    copy(p_block_t, s_block_t);
+    copy(p_block_t_mma, s_block_t);
+    stream_sub_tile(dp_block_t, d_smem, 0); // dP - D
+    mul(ds_block_t, p_block_t, dp_block_t); // dS = P \odot (dP - D)
+
+    if constexpr (D == 64) {
+      mul(ds_block_t, ds_block_t, 0.125f);
+    } else {
+      mul(ds_block_t, ds_block_t, 0.08838834764f);
     }
-    tma::store_async_wait(); 
+
+    warpgroup::mma_AB(vg_reg, p_block_t_mma, og_smem[0]); // dV += P^TdO
+    warpgroup::mma_commit_group();
+    copy(ds_block_t_mma, ds_block_t);
+    warpgroup::store(ds_smem_t[0], ds_block_t);
+    warpgroup::mma_async_wait();
+
+    warpgroup::mma_AB(kg_reg, ds_block_t_mma, q_smem[0]); // dK += dS^TQ
+    warpgroup::mma_commit_group();
+    warpgroup::mma_async_wait();
+
+    rt_fl<16, G::tile_width> qg_reg;
+    __syncthreads(); // wait for sd_smem shared memory write
+    warpgroup::mm_AtB(qg_reg, ds_smem_t[0], k_smem[0]); // delat dQ = dSK
+    warpgroup::mma_commit_group();
+    tma::store_async_wait();
+    warpgroup::mma_async_wait();
+    // store qg to shared memory
+    warpgroup::store(qg_smem, qg_reg);
+    __syncthreads();
+
+    // store and add dQ to global memory
+    if (threadIdx.x / 32 == 0) {
+      coord<qg_tile> tile_idx = {blockIdx.z, blockIdx.y, store_qg_block_index,
+                                 0};
+      tma::store_add_async(g.qg, qg_smem, tile_idx);
+    }
+  }
+
+  // store kq and vq
+
+  // ! the following two line seems unnecessary.
+  tma::store_async_wait(); // ensure qg is finished
+  __syncthreads();
+
+  warpgroup::store(kg_smem[0], kg_reg);
+  __syncthreads();
+  if (threadIdx.x / 32 == 0) {
+    coord<kg_tile> tile_idx = {blockIdx.z, kv_head_idx, blockIdx.x, 0};
+    tma::store_add_async(g.kg, kg_smem[0], tile_idx);
+    tma::store_commit_group();
+  }
+
+  warpgroup::store(vg_smem[0], vg_reg);
+  __syncthreads();
+  if (kittens::warpid() % 4 == 0) {
+    coord<vg_tile> tile_idx = {blockIdx.z, kv_head_idx, blockIdx.x, 0};
+    tma::store_add_async(g.vg, vg_smem[0], tile_idx);
+    tma::store_commit_group();
+  }
+  tma::store_async_wait();
 }
 
 #include "pyutils/torch_helpers.cuh"
 #include <ATen/cuda/CUDAContext.h>
 #include <iostream>
 
-std::vector<torch::Tensor> 
-block_sparse_attention_forward(torch::Tensor q, torch::Tensor k, torch::Tensor v, torch::Tensor q2k_block_sparse_index, torch::Tensor q2k_block_sparse_num)
-{
-    CHECK_INPUT(q);
-    CHECK_INPUT(k);
-    CHECK_INPUT(v);
+std::vector<torch::Tensor> block_sparse_attention_forward(
+    torch::Tensor q, torch::Tensor k, torch::Tensor v,
+    torch::Tensor q2k_block_sparse_index, torch::Tensor q2k_block_sparse_num) {
+  CHECK_INPUT(q);
+  CHECK_INPUT(k);
+  CHECK_INPUT(v);
 
-    auto batch    = q.size(0);
-    auto seq_len  = q.size(2); 
-    auto head_dim = q.size(3); 
-    auto qo_heads = q.size(1);
-    auto kv_heads = k.size(1);
-    auto max_kv_blocks_per_q = q2k_block_sparse_index.size(3);
-    // check to see that these dimensions match for all inputs
-    TORCH_CHECK(q.size(0) == batch, "Q batch dimension - idx 0 - must match for all inputs");
-    TORCH_CHECK(k.size(0) == batch, "K batch dimension - idx 0 - must match for all inputs");
-    TORCH_CHECK(v.size(0) == batch, "V batch dimension - idx 0 - must match for all inputs");
-    TORCH_CHECK(q2k_block_sparse_index.size(0) == batch, "q2k_block_sparse_index batch dimension - idx 0 - must match for all inputs");
-    TORCH_CHECK(q2k_block_sparse_num.size(0) == batch, "q2k_block_sparse_num batch dimension - idx 0 - must match for all inputs");
+  auto batch = q.size(0);
+  auto seq_len = q.size(2);
+  auto head_dim = q.size(3);
+  auto qo_heads = q.size(1);
+  auto kv_heads = k.size(1);
+  auto max_kv_blocks_per_q = q2k_block_sparse_index.size(3);
+  // check to see that these dimensions match for all inputs
+  TORCH_CHECK(q.size(0) == batch,
+              "Q batch dimension - idx 0 - must match for all inputs");
+  TORCH_CHECK(k.size(0) == batch,
+              "K batch dimension - idx 0 - must match for all inputs");
+  TORCH_CHECK(v.size(0) == batch,
+              "V batch dimension - idx 0 - must match for all inputs");
+  TORCH_CHECK(q2k_block_sparse_index.size(0) == batch,
+              "q2k_block_sparse_index batch dimension - idx 0 - must match for "
+              "all inputs");
+  TORCH_CHECK(q2k_block_sparse_num.size(0) == batch,
+              "q2k_block_sparse_num batch dimension - idx 0 - must match for "
+              "all inputs");
 
-    TORCH_CHECK(q.size(2) == seq_len, "Q sequence length dimension - idx 2 - must match for all inputs");
-    TORCH_CHECK(k.size(2) == seq_len, "K sequence length dimension - idx 2 - must match for all inputs");
-    TORCH_CHECK(v.size(2) == seq_len, "V sequence length dimension - idx 2 - must match for all inputs");
-    TORCH_CHECK(q2k_block_sparse_index.size(2) == seq_len / BLOCK_M, "q2k_block_sparse_index idx 2 - must match seq_len / BLOCK_M");
-    TORCH_CHECK(q2k_block_sparse_num.size(2) == seq_len / BLOCK_M, "q2k_block_sparse_num idx 2 - must match seq_len / BLOCK_M");
+  TORCH_CHECK(
+      q.size(2) == seq_len,
+      "Q sequence length dimension - idx 2 - must match for all inputs");
+  TORCH_CHECK(
+      k.size(2) == seq_len*CP,
+      "K sequence length dimension - idx 2 - must match for all inputs sss");
+  TORCH_CHECK(
+      v.size(2) == seq_len*CP,
+      "V sequence length dimension - idx 2 - must match for all inputs");
+  TORCH_CHECK(q2k_block_sparse_index.size(2) == seq_len / BLOCK_M,
+              "q2k_block_sparse_index idx 2 - must match seq_len / BLOCK_M");
+  TORCH_CHECK(q2k_block_sparse_num.size(2) == seq_len / BLOCK_M,
+              "q2k_block_sparse_num idx 2 - must match seq_len / BLOCK_M");
 
+  TORCH_CHECK(
+      q.size(3) == head_dim,
+      "Q head dimension - idx 3 - must match for all non-vector inputs");
+  TORCH_CHECK(
+      k.size(3) == head_dim,
+      "K head dimension - idx 3 - must match for all non-vector inputs");
+  TORCH_CHECK(
+      v.size(3) == head_dim,
+      "V head dimension - idx 3 - must match for all non-vector inputs");
 
-    TORCH_CHECK(q.size(3) == head_dim, "Q head dimension - idx 3 - must match for all non-vector inputs");
-    TORCH_CHECK(k.size(3) == head_dim, "K head dimension - idx 3 - must match for all non-vector inputs");
-    TORCH_CHECK(v.size(3) == head_dim, "V head dimension - idx 3 - must match for all non-vector inputs");
+  TORCH_CHECK(qo_heads >= kv_heads,
+              "QO heads must be greater than or equal to KV heads");
+  TORCH_CHECK(qo_heads % kv_heads == 0,
+              "QO heads must be divisible by KV heads");
+  TORCH_CHECK(q.size(1) == qo_heads,
+              "QO head dimension - idx 1 - must match for all inputs");
+  TORCH_CHECK(k.size(1) == kv_heads,
+              "KV head dimension - idx 1 - must match for all inputs");
+  TORCH_CHECK(v.size(1) == kv_heads,
+              "KV head dimension - idx 1 - must match for all inputs");
+  TORCH_CHECK(q2k_block_sparse_index.size(1) == qo_heads,
+              "q2k_block_sparse_index head dimension - idx 1 - must match for "
+              "all inputs");
+  TORCH_CHECK(q2k_block_sparse_num.size(1) == qo_heads,
+              "q2k_block_sparse_num head dimension - idx 1 - must match for "
+              "all inputs");
+  auto hr = qo_heads / kv_heads;
 
-    TORCH_CHECK(qo_heads >= kv_heads, "QO heads must be greater than or equal to KV heads");
-    TORCH_CHECK(qo_heads % kv_heads == 0, "QO heads must be divisible by KV heads");
-    TORCH_CHECK(q.size(1) == qo_heads, "QO head dimension - idx 1 - must match for all inputs");
-    TORCH_CHECK(k.size(1) == kv_heads, "KV head dimension - idx 1 - must match for all inputs");
-    TORCH_CHECK(v.size(1) == kv_heads, "KV head dimension - idx 1 - must match for all inputs");  
-    TORCH_CHECK(q2k_block_sparse_index.size(1) == qo_heads, "q2k_block_sparse_index head dimension - idx 1 - must match for all inputs");
-    TORCH_CHECK(q2k_block_sparse_num.size(1) == qo_heads, "q2k_block_sparse_num head dimension - idx 1 - must match for all inputs");
-    auto hr = qo_heads / kv_heads;
+  c10::BFloat16 *q_ptr = q.data_ptr<c10::BFloat16>();
+  c10::BFloat16 *k_ptr = k.data_ptr<c10::BFloat16>();
+  c10::BFloat16 *v_ptr = v.data_ptr<c10::BFloat16>();
 
-    c10::BFloat16* q_ptr = q.data_ptr<c10::BFloat16>();
-    c10::BFloat16* k_ptr = k.data_ptr<c10::BFloat16>();
-    c10::BFloat16* v_ptr = v.data_ptr<c10::BFloat16>();
+  bf16 *d_q = reinterpret_cast<bf16 *>(q_ptr);
+  bf16 *d_k = reinterpret_cast<bf16 *>(k_ptr);
+  bf16 *d_v = reinterpret_cast<bf16 *>(v_ptr);
 
-    bf16*  d_q = reinterpret_cast<bf16*>(q_ptr);
-    bf16*  d_k = reinterpret_cast<bf16*>(k_ptr);
-    bf16*  d_v = reinterpret_cast<bf16*>(v_ptr);
-    
-    // for the returned outputs
-    torch::Tensor o     = torch::empty({static_cast<const uint>(batch), 
-                                        static_cast<const uint>(qo_heads), 
-                                        static_cast<const uint>(seq_len), 
-                                        static_cast<const uint>(head_dim)}, v.options());
-    
-    torch::Tensor l_vec = torch::empty({static_cast<const uint>(batch), 
-                                        static_cast<const uint>(qo_heads), 
-                                        static_cast<const uint>(seq_len), 
-                                        static_cast<const uint>(1)}, 
-                                        torch::TensorOptions().dtype(torch::kFloat).device(q.device()).memory_format(at::MemoryFormat::Contiguous));
-        
+  // for the returned outputs
+  torch::Tensor o = torch::empty(
+      {static_cast<const uint>(batch), static_cast<const uint>(qo_heads),
+       static_cast<const uint>(seq_len), static_cast<const uint>(head_dim)},
+      v.options());
 
-    bf16*  o_ptr = reinterpret_cast<bf16*>(o.data_ptr<c10::BFloat16>());
-    bf16*  d_o   = reinterpret_cast<bf16*>(o_ptr);
+  torch::Tensor l_vec = torch::empty(
+      {static_cast<const uint>(batch), static_cast<const uint>(qo_heads),
+       static_cast<const uint>(seq_len), static_cast<const uint>(1)},
+      torch::TensorOptions()
+          .dtype(torch::kFloat)
+          .device(q.device())
+          .memory_format(at::MemoryFormat::Contiguous));
 
-    float* l_ptr = reinterpret_cast<float*>(l_vec.data_ptr<float>());
-    float* d_l   = reinterpret_cast<float*>(l_ptr);
+  bf16 *o_ptr = reinterpret_cast<bf16 *>(o.data_ptr<c10::BFloat16>());
+  bf16 *d_o = reinterpret_cast<bf16 *>(o_ptr);
 
-    //cudadevicesynchronize();
-    const c10::cuda::OptionalCUDAGuard device_guard(q.device());    
-    const cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream(); 
+  float *l_ptr = reinterpret_cast<float *>(l_vec.data_ptr<float>());
+  float *d_l = reinterpret_cast<float *>(l_ptr);
 
-    if (head_dim == 64) {
-        using q_tile    =         st_bf<fwd_attend_ker_tile_dims<64>::qo_height, fwd_attend_ker_tile_dims<64>::tile_width>;
-        using k_tile    =         st_bf<fwd_attend_ker_tile_dims<64>::kv_height, fwd_attend_ker_tile_dims<64>::tile_width>;
-        using v_tile    =         st_bf<fwd_attend_ker_tile_dims<64>::kv_height, fwd_attend_ker_tile_dims<64>::tile_width>;
-        using l_col_vec = col_vec<st_fl<fwd_attend_ker_tile_dims<64>::qo_height, fwd_attend_ker_tile_dims<64>::tile_width>>;
-        using o_tile    =         st_bf<fwd_attend_ker_tile_dims<64>::qo_height, fwd_attend_ker_tile_dims<64>::tile_width>;
+  // cudadevicesynchronize();
+  const c10::cuda::OptionalCUDAGuard device_guard(q.device());
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
 
-        using q_global = gl<bf16,  -1, -1, -1, -1, q_tile>;
-        using k_global = gl<bf16,  -1, -1, -1, -1, k_tile>;
-        using v_global = gl<bf16,  -1, -1, -1, -1, v_tile>;
-        using l_global = gl<float, -1, -1, -1, -1, l_col_vec>;
-        using o_global = gl<bf16,  -1, -1, -1, -1, o_tile>;
+  if (head_dim == 64) {
+    using q_tile = st_bf<fwd_attend_ker_tile_dims<64>::qo_height,
+                         fwd_attend_ker_tile_dims<64>::tile_width>;
+    using k_tile = st_bf<fwd_attend_ker_tile_dims<64>::kv_height,
+                         fwd_attend_ker_tile_dims<64>::tile_width>;
+    using v_tile = st_bf<fwd_attend_ker_tile_dims<64>::kv_height,
+                         fwd_attend_ker_tile_dims<64>::tile_width>;
+    using l_col_vec = col_vec<st_fl<fwd_attend_ker_tile_dims<64>::qo_height,
+                                    fwd_attend_ker_tile_dims<64>::tile_width>>;
+    using o_tile = st_bf<fwd_attend_ker_tile_dims<64>::qo_height,
+                         fwd_attend_ker_tile_dims<64>::tile_width>;
 
-        using globals      = fwd_globals<64>;
+    using q_global = gl<bf16, -1, -1, -1, -1, q_tile>;
+    using k_global = gl<bf16, -1, -1, -1, -1, k_tile>;
+    using v_global = gl<bf16, -1, -1, -1, -1, v_tile>;
+    using l_global = gl<float, -1, -1, -1, -1, l_col_vec>;
+    using o_global = gl<bf16, -1, -1, -1, -1, o_tile>;
 
-        q_global qg_arg{d_q, static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), static_cast<unsigned int>(seq_len), 64U};
-        k_global kg_arg{d_k, static_cast<unsigned int>(batch), static_cast<unsigned int>(kv_heads), static_cast<unsigned int>(seq_len), 64U};
-        v_global vg_arg{d_v, static_cast<unsigned int>(batch), static_cast<unsigned int>(kv_heads), static_cast<unsigned int>(seq_len), 64U};
-        l_global lg_arg{d_l, static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), 1U,   static_cast<unsigned int>(seq_len)};
-        o_global og_arg{d_o, static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), static_cast<unsigned int>(seq_len), 64U};
+    using globals = fwd_globals<64>;
 
-        globals g{qg_arg, kg_arg, vg_arg, lg_arg, og_arg, static_cast<int>(seq_len), static_cast<int>(hr), static_cast<int>(max_kv_blocks_per_q), reinterpret_cast<int32_t*>(q2k_block_sparse_index.data_ptr()), reinterpret_cast<int32_t*>(q2k_block_sparse_num.data_ptr())};
+    q_global qg_arg{d_q, static_cast<unsigned int>(batch),
+                    static_cast<unsigned int>(qo_heads),
+                    static_cast<unsigned int>(seq_len), 64U};
+    k_global kg_arg{d_k, static_cast<unsigned int>(batch),
+                    static_cast<unsigned int>(kv_heads),
+                    static_cast<unsigned int>(seq_len*CP), 64U};
+    v_global vg_arg{d_v, static_cast<unsigned int>(batch),
+                    static_cast<unsigned int>(kv_heads),
+                    static_cast<unsigned int>(seq_len*CP), 64U};
+    l_global lg_arg{d_l, static_cast<unsigned int>(batch),
+                    static_cast<unsigned int>(qo_heads), 1U,
+                    static_cast<unsigned int>(seq_len)};
+    o_global og_arg{d_o, static_cast<unsigned int>(batch),
+                    static_cast<unsigned int>(qo_heads),
+                    static_cast<unsigned int>(seq_len), 64U};
 
-        constexpr int mem_size = 54000;
+    globals g{qg_arg,
+              kg_arg,
+              vg_arg,
+              lg_arg,
+              og_arg,
+              static_cast<int>(seq_len),
+              static_cast<int>(hr),
+              static_cast<int>(max_kv_blocks_per_q),
+              reinterpret_cast<int32_t *>(q2k_block_sparse_index.data_ptr()),
+              reinterpret_cast<int32_t *>(q2k_block_sparse_num.data_ptr())};
 
-        dim3 grid(seq_len/(64), qo_heads, batch);
+    constexpr int mem_size = 54000;
 
-        cudaFuncSetAttribute(
-            fwd_attend_ker<64>,
-            cudaFuncAttributeMaxDynamicSharedMemorySize,
-            mem_size
-        );
+    dim3 grid(seq_len / (64), qo_heads, batch);
 
-        fwd_attend_ker<64><<<grid, (128), mem_size, stream>>>(g);
+    cudaFuncSetAttribute(fwd_attend_ker<64>,
+                         cudaFuncAttributeMaxDynamicSharedMemorySize, mem_size);
 
-        CHECK_CUDA_ERROR(cudaGetLastError());
-        // cudaStreamSynchronize(stream);
-    }
+    fwd_attend_ker<64><<<grid, (128), mem_size, stream>>>(g);
 
-    if (head_dim == 128) {
-        using q_tile    =         st_bf<fwd_attend_ker_tile_dims<128>::qo_height, fwd_attend_ker_tile_dims<128>::tile_width>;
-        using k_tile    =         st_bf<fwd_attend_ker_tile_dims<128>::kv_height, fwd_attend_ker_tile_dims<128>::tile_width>;
-        using v_tile    =         st_bf<fwd_attend_ker_tile_dims<128>::kv_height, fwd_attend_ker_tile_dims<128>::tile_width>;
-        using l_col_vec = col_vec<st_fl<fwd_attend_ker_tile_dims<128>::qo_height, fwd_attend_ker_tile_dims<128>::tile_width>>;
-        using o_tile    =         st_bf<fwd_attend_ker_tile_dims<128>::qo_height, fwd_attend_ker_tile_dims<128>::tile_width>;
+    CHECK_CUDA_ERROR(cudaGetLastError());
+    // cudaStreamSynchronize(stream);
+  }
 
-        using q_global = gl<bf16,  -1, -1, -1, -1, q_tile>;
-        using k_global = gl<bf16,  -1, -1, -1, -1, k_tile>;
-        using v_global = gl<bf16,  -1, -1, -1, -1, v_tile>;
-        using l_global = gl<float, -1, -1, -1, -1, l_col_vec>;
-        using o_global = gl<bf16,  -1, -1, -1, -1, o_tile>;
+  if (head_dim == 128) {
+    using q_tile = st_bf<fwd_attend_ker_tile_dims<128>::qo_height,
+                         fwd_attend_ker_tile_dims<128>::tile_width>;
+    using k_tile = st_bf<fwd_attend_ker_tile_dims<128>::kv_height,
+                         fwd_attend_ker_tile_dims<128>::tile_width>;
+    using v_tile = st_bf<fwd_attend_ker_tile_dims<128>::kv_height,
+                         fwd_attend_ker_tile_dims<128>::tile_width>;
+    using l_col_vec = col_vec<st_fl<fwd_attend_ker_tile_dims<128>::qo_height,
+                                    fwd_attend_ker_tile_dims<128>::tile_width>>;
+    using o_tile = st_bf<fwd_attend_ker_tile_dims<128>::qo_height,
+                         fwd_attend_ker_tile_dims<128>::tile_width>;
 
-        using globals      = fwd_globals<128>;
+    using q_global = gl<bf16, -1, -1, -1, -1, q_tile>;
+    using k_global = gl<bf16, -1, -1, -1, -1, k_tile>;
+    using v_global = gl<bf16, -1, -1, -1, -1, v_tile>;
+    using l_global = gl<float, -1, -1, -1, -1, l_col_vec>;
+    using o_global = gl<bf16, -1, -1, -1, -1, o_tile>;
 
-        q_global qg_arg{d_q, static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), static_cast<unsigned int>(seq_len), 128U};
-        k_global kg_arg{d_k, static_cast<unsigned int>(batch), static_cast<unsigned int>(kv_heads), static_cast<unsigned int>(seq_len), 128U};
-        v_global vg_arg{d_v, static_cast<unsigned int>(batch), static_cast<unsigned int>(kv_heads), static_cast<unsigned int>(seq_len), 128U};
-        l_global lg_arg{d_l, static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), 1U,   static_cast<unsigned int>(seq_len)};
-        o_global og_arg{d_o, static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), static_cast<unsigned int>(seq_len), 128U};
+    using globals = fwd_globals<128>;
 
-        globals g{qg_arg, kg_arg, vg_arg, lg_arg, og_arg, static_cast<int>(seq_len), static_cast<int>(hr), static_cast<int>(max_kv_blocks_per_q), reinterpret_cast<int32_t*>(q2k_block_sparse_index.data_ptr()), reinterpret_cast<int32_t*>(q2k_block_sparse_num.data_ptr())};
+    q_global qg_arg{d_q, static_cast<unsigned int>(batch),
+                    static_cast<unsigned int>(qo_heads),
+                    static_cast<unsigned int>(seq_len), 128U};
+    k_global kg_arg{d_k, static_cast<unsigned int>(batch),
+                    static_cast<unsigned int>(kv_heads),
+                    static_cast<unsigned int>(seq_len*CP), 128U};
+    v_global vg_arg{d_v, static_cast<unsigned int>(batch),
+                    static_cast<unsigned int>(kv_heads),
+                    static_cast<unsigned int>(seq_len*CP), 128U};
+    l_global lg_arg{d_l, static_cast<unsigned int>(batch),
+                    static_cast<unsigned int>(qo_heads), 1U,
+                    static_cast<unsigned int>(seq_len)};
+    o_global og_arg{d_o, static_cast<unsigned int>(batch),
+                    static_cast<unsigned int>(qo_heads),
+                    static_cast<unsigned int>(seq_len), 128U};
 
-        constexpr int mem_size = 54000;
+    globals g{qg_arg,
+              kg_arg,
+              vg_arg,
+              lg_arg,
+              og_arg,
+              static_cast<int>(seq_len),
+              static_cast<int>(hr),
+              static_cast<int>(max_kv_blocks_per_q),
+              reinterpret_cast<int32_t *>(q2k_block_sparse_index.data_ptr()),
+              reinterpret_cast<int32_t *>(q2k_block_sparse_num.data_ptr())};
 
-        dim3 grid(seq_len/(64), qo_heads, batch);
+    constexpr int mem_size = 54000;
 
-        cudaFuncSetAttribute(
-            fwd_attend_ker<128>,
-            cudaFuncAttributeMaxDynamicSharedMemorySize,
-            mem_size
-        );
+    dim3 grid(seq_len / (64), qo_heads, batch);
 
-        fwd_attend_ker<128><<<grid, (128), mem_size, stream>>>(g);
+    cudaFuncSetAttribute(fwd_attend_ker<128>,
+                         cudaFuncAttributeMaxDynamicSharedMemorySize, mem_size);
 
-        CHECK_CUDA_ERROR(cudaGetLastError());
-        // cudaStreamSynchronize(stream);
-    }
+    fwd_attend_ker<128><<<grid, (128), mem_size, stream>>>(g);
 
-    return {o, l_vec};
-    //cudadevicesynchronize();
+    CHECK_CUDA_ERROR(cudaGetLastError());
+    // cudaStreamSynchronize(stream);
+  }
+
+  return {o, l_vec};
+  // cudadevicesynchronize();
 }
 
-std::vector<torch::Tensor> 
-block_sparse_attention_backward(torch::Tensor q, 
-                   torch::Tensor k, 
-                   torch::Tensor v, 
-                   torch::Tensor o, 
-                   torch::Tensor l_vec,
-                   torch::Tensor og,
-                   torch::Tensor k2q_block_sparse_index,
-                   torch::Tensor k2q_block_sparse_num)
-{
-    CHECK_INPUT(q);
-    CHECK_INPUT(k);
-    CHECK_INPUT(v);
-    CHECK_INPUT(l_vec);
-    CHECK_INPUT(o);
-    CHECK_INPUT(og);
+std::vector<torch::Tensor> block_sparse_attention_backward(
+    torch::Tensor q, torch::Tensor k, torch::Tensor v, torch::Tensor o,
+    torch::Tensor l_vec, torch::Tensor og, torch::Tensor k2q_block_sparse_index,
+    torch::Tensor k2q_block_sparse_num) {
+  CHECK_INPUT(q);
+  CHECK_INPUT(k);
+  CHECK_INPUT(v);
+  CHECK_INPUT(l_vec);
+  CHECK_INPUT(o);
+  CHECK_INPUT(og);
 
-    auto batch    = q.size(0);
-    auto seq_len  = q.size(2);
-    auto head_dim = q.size(3);
-    auto max_q_blocks_per_kv = k2q_block_sparse_index.size(3);
+  auto batch = q.size(0);
+  auto seq_len = q.size(2);
+  auto head_dim = q.size(3);
+  auto max_q_blocks_per_kv = k2q_block_sparse_index.size(3);
 
-    // check to see that these dimensions match for all inputs
-    TORCH_CHECK(q.size(0)     == batch, "Q  batch dimension - idx 0 - must match for all inputs");
-    TORCH_CHECK(k.size(0)     == batch, "K  batch dimension - idx 0 - must match for all inputs");
-    TORCH_CHECK(v.size(0)     == batch, "V  batch dimension - idx 0 - must match for all inputs");
-    TORCH_CHECK(l_vec.size(0) == batch, "L  batch dimension - idx 0 - must match for all inputs");
-    TORCH_CHECK(o.size(0)     == batch, "O  batch dimension - idx 0 - must match for all inputs");
-    TORCH_CHECK(og.size(0)    == batch, "OG batch dimension - idx 0 - must match for all inputs");
-    TORCH_CHECK(k2q_block_sparse_index.size(0) == batch, "k2q_block_sparse_index batch dimension - idx 0 - must match for all inputs");
-    TORCH_CHECK(k2q_block_sparse_num.size(0) == batch, "k2q_block_sparse_num batch dimension - idx 0 - must match for all inputs");
+  // check to see that these dimensions match for all inputs
+  TORCH_CHECK(q.size(0) == batch,
+              "Q  batch dimension - idx 0 - must match for all inputs");
+  TORCH_CHECK(k.size(0) == batch,
+              "K  batch dimension - idx 0 - must match for all inputs");
+  TORCH_CHECK(v.size(0) == batch,
+              "V  batch dimension - idx 0 - must match for all inputs");
+  TORCH_CHECK(l_vec.size(0) == batch,
+              "L  batch dimension - idx 0 - must match for all inputs");
+  TORCH_CHECK(o.size(0) == batch,
+              "O  batch dimension - idx 0 - must match for all inputs");
+  TORCH_CHECK(og.size(0) == batch,
+              "OG batch dimension - idx 0 - must match for all inputs");
+  TORCH_CHECK(k2q_block_sparse_index.size(0) == batch,
+              "k2q_block_sparse_index batch dimension - idx 0 - must match for "
+              "all inputs");
+  TORCH_CHECK(k2q_block_sparse_num.size(0) == batch,
+              "k2q_block_sparse_num batch dimension - idx 0 - must match for "
+              "all inputs");
 
+  TORCH_CHECK(
+      q.size(2) == seq_len,
+      "Q  sequence length dimension - idx 2 - must match for all inputs");
+  TORCH_CHECK(
+      k.size(2) == seq_len*CP,
+      "K  sequence length dimension - idx 2 - must match for all inputs");
+  TORCH_CHECK(
+      v.size(2) == seq_len*CP,
+      "V  sequence length dimension - idx 2 - must match for all inputs");
+  TORCH_CHECK(
+      l_vec.size(2) == seq_len,
+      "L  sequence length dimension - idx 2 - must match for all inputs");
+  TORCH_CHECK(
+      o.size(2) == seq_len,
+      "O  sequence length dimension - idx 2 - must match for all inputs");
+  TORCH_CHECK(
+      og.size(2) == seq_len,
+      "OG sequence length dimension - idx 2 - must match for all inputs");
+  TORCH_CHECK(k2q_block_sparse_index.size(2) == seq_len*CP / BLOCK_N,
+              "k2q_block_sparse_index idx 2 - must match seq_len / BLOCK_N");
+  TORCH_CHECK(k2q_block_sparse_num.size(2) == seq_len*CP / BLOCK_N,
+              "k2q_block_sparse_num idx 2 - must match seq_len / BLOCK_N");
 
-    TORCH_CHECK(q.size(2)     == seq_len, "Q  sequence length dimension - idx 2 - must match for all inputs");
-    TORCH_CHECK(k.size(2)     == seq_len, "K  sequence length dimension - idx 2 - must match for all inputs");
-    TORCH_CHECK(v.size(2)     == seq_len, "V  sequence length dimension - idx 2 - must match for all inputs");
-    TORCH_CHECK(l_vec.size(2) == seq_len, "L  sequence length dimension - idx 2 - must match for all inputs");
-    TORCH_CHECK(o.size(2)     == seq_len, "O  sequence length dimension - idx 2 - must match for all inputs");
-    TORCH_CHECK(og.size(2)    == seq_len, "OG sequence length dimension - idx 2 - must match for all inputs");
-    TORCH_CHECK(k2q_block_sparse_index.size(2) == seq_len / BLOCK_N, "k2q_block_sparse_index idx 2 - must match seq_len / BLOCK_N");
-    TORCH_CHECK(k2q_block_sparse_num.size(2) == seq_len / BLOCK_N, "k2q_block_sparse_num idx 2 - must match seq_len / BLOCK_N");
+  TORCH_CHECK(
+      q.size(3) == head_dim,
+      "Q  head dimension - idx 3 - must match for all non-vector inputs");
+  TORCH_CHECK(
+      k.size(3) == head_dim,
+      "K  head dimension - idx 3 - must match for all non-vector inputs");
+  TORCH_CHECK(
+      v.size(3) == head_dim,
+      "V  head dimension - idx 3 - must match for all non-vector inputs");
+  TORCH_CHECK(
+      o.size(3) == head_dim,
+      "O  head dimension - idx 3 - must match for all non-vector inputs");
+  TORCH_CHECK(
+      og.size(3) == head_dim,
+      "OG head dimension - idx 3 - must match for all non-vector inputs");
 
-    TORCH_CHECK(q.size(3)  == head_dim, "Q  head dimension - idx 3 - must match for all non-vector inputs");
-    TORCH_CHECK(k.size(3)  == head_dim, "K  head dimension - idx 3 - must match for all non-vector inputs");
-    TORCH_CHECK(v.size(3)  == head_dim, "V  head dimension - idx 3 - must match for all non-vector inputs");
-    TORCH_CHECK(o.size(3)  == head_dim, "O  head dimension - idx 3 - must match for all non-vector inputs");
-    TORCH_CHECK(og.size(3) == head_dim, "OG head dimension - idx 3 - must match for all non-vector inputs");
-    
+  auto qo_heads = q.size(1);
+  auto kv_heads = k.size(1);
 
+  TORCH_CHECK(qo_heads >= kv_heads,
+              "Q heads must be greater than or equal to K and V heads");
+  TORCH_CHECK(qo_heads % kv_heads == 0,
+              "Q heads must be divisible by KV heads");
 
-    auto qo_heads = q.size(1);
-    auto kv_heads = k.size(1);
+  TORCH_CHECK(q.size(1) == qo_heads,
+              "Q  heads dimension - idx 1 - must match for all inputs");
+  TORCH_CHECK(l_vec.size(1) == qo_heads,
+              "L  heads dimension - idx 1 - must match for all inputs");
+  TORCH_CHECK(o.size(1) == qo_heads,
+              "O  heads dimension - idx 1 - must match for all inputs");
+  TORCH_CHECK(og.size(1) == qo_heads,
+              "OG heads dimension - idx 1 - must match for all inputs");
+  TORCH_CHECK(k.size(1) == kv_heads,
+              "K  heads dimension - idx 1 - must match for all inputs");
+  TORCH_CHECK(v.size(1) == kv_heads,
+              "V  heads dimension - idx 1 - must match for all inputs");
+  TORCH_CHECK(k2q_block_sparse_index.size(1) == kv_heads,
+              "k2q_block_sparse_index heads dimension - idx 1 - must match for "
+              "all inputs");
+  TORCH_CHECK(k2q_block_sparse_num.size(1) == kv_heads,
+              "k2q_block_sparse_num heads dimension - idx 1 - must match for "
+              "all inputs");
+  auto hr = qo_heads / kv_heads;
 
-    TORCH_CHECK(qo_heads >= kv_heads,     "Q heads must be greater than or equal to K and V heads");
-    TORCH_CHECK(qo_heads % kv_heads == 0, "Q heads must be divisible by KV heads");
+  c10::BFloat16 *q_ptr = q.data_ptr<c10::BFloat16>();
+  c10::BFloat16 *k_ptr = k.data_ptr<c10::BFloat16>();
+  c10::BFloat16 *v_ptr = v.data_ptr<c10::BFloat16>();
+  c10::BFloat16 *o_ptr = o.data_ptr<c10::BFloat16>();
+  c10::BFloat16 *og_ptr = og.data_ptr<c10::BFloat16>();
+  float *l_ptr = l_vec.data_ptr<float>();
 
-    TORCH_CHECK(q.size(1)     == qo_heads, "Q  heads dimension - idx 1 - must match for all inputs");
-    TORCH_CHECK(l_vec.size(1) == qo_heads, "L  heads dimension - idx 1 - must match for all inputs");
-    TORCH_CHECK(o.size(1)     == qo_heads, "O  heads dimension - idx 1 - must match for all inputs");
-    TORCH_CHECK(og.size(1)    == qo_heads, "OG heads dimension - idx 1 - must match for all inputs");
-    TORCH_CHECK(k.size(1)  == kv_heads, "K  heads dimension - idx 1 - must match for all inputs");
-    TORCH_CHECK(v.size(1)  == kv_heads, "V  heads dimension - idx 1 - must match for all inputs");
-    TORCH_CHECK(k2q_block_sparse_index.size(1) == kv_heads, "k2q_block_sparse_index heads dimension - idx 1 - must match for all inputs");
-    TORCH_CHECK(k2q_block_sparse_num.size(1) == kv_heads, "k2q_block_sparse_num heads dimension - idx 1 - must match for all inputs");
-    auto hr = qo_heads / kv_heads;
+  torch::Tensor qg = torch::zeros(
+      {static_cast<const uint>(batch), static_cast<const uint>(qo_heads),
+       static_cast<const uint>(seq_len), static_cast<const uint>(head_dim)},
+      l_vec.options());
+  torch::Tensor kg = torch::zeros(
+      {static_cast<const uint>(batch), static_cast<const uint>(kv_heads),
+       static_cast<const uint>(seq_len*CP), static_cast<const uint>(head_dim)},
+      l_vec.options());
+  torch::Tensor vg = torch::zeros(
+      {static_cast<const uint>(batch), static_cast<const uint>(kv_heads),
+       static_cast<const uint>(seq_len*CP), static_cast<const uint>(head_dim)},
+      l_vec.options());
 
-    c10::BFloat16* q_ptr  = q.data_ptr<c10::BFloat16>();
-    c10::BFloat16* k_ptr  = k.data_ptr<c10::BFloat16>();
-    c10::BFloat16* v_ptr  = v.data_ptr<c10::BFloat16>();
-    c10::BFloat16* o_ptr  = o.data_ptr<c10::BFloat16>();
-    c10::BFloat16* og_ptr = og.data_ptr<c10::BFloat16>();
-    float*         l_ptr  = l_vec.data_ptr<float>();
+  torch::Tensor d_vec = torch::empty(
+      {static_cast<const uint>(batch), static_cast<const uint>(qo_heads),
+       static_cast<const uint>(seq_len), static_cast<const uint>(1)},
+      l_vec.options());
 
-    torch::Tensor qg = torch::zeros({static_cast<const uint>(batch), 
-                                     static_cast<const uint>(qo_heads), 
-                                     static_cast<const uint>(seq_len), 
-                                     static_cast<const uint>(head_dim)},   l_vec.options());
-    torch::Tensor kg = torch::zeros({static_cast<const uint>(batch), 
-                                     static_cast<const uint>(kv_heads), 
-                                     static_cast<const uint>(seq_len), 
-                                     static_cast<const uint>(head_dim)},   l_vec.options());
-    torch::Tensor vg = torch::zeros({static_cast<const uint>(batch), 
-                                     static_cast<const uint>(kv_heads), 
-                                     static_cast<const uint>(seq_len), 
-                                     static_cast<const uint>(head_dim)},   l_vec.options());
-    
-    torch::Tensor d_vec = torch::empty({static_cast<const uint>(batch), 
-                                        static_cast<const uint>(qo_heads), 
-                                        static_cast<const uint>(seq_len), 
-                                        static_cast<const uint>(1)},       l_vec.options());
+  float *qg_ptr = qg.data_ptr<float>();
+  float *kg_ptr = kg.data_ptr<float>();
+  float *vg_ptr = vg.data_ptr<float>();
+  float *d_ptr = d_vec.data_ptr<float>();
 
-    float*         qg_ptr = qg.data_ptr<float>();
-    float*         kg_ptr = kg.data_ptr<float>();
-    float*         vg_ptr = vg.data_ptr<float>();
-    float*         d_ptr  = d_vec.data_ptr<float>();
+  bf16 *d_q = reinterpret_cast<bf16 *>(q_ptr);
+  bf16 *d_k = reinterpret_cast<bf16 *>(k_ptr);
+  bf16 *d_v = reinterpret_cast<bf16 *>(v_ptr);
+  bf16 *d_o = reinterpret_cast<bf16 *>(o_ptr);
+  bf16 *d_og = reinterpret_cast<bf16 *>(og_ptr);
+  float *d_l = reinterpret_cast<float *>(l_ptr);
+  float *d_d = reinterpret_cast<float *>(d_ptr);
+  float *d_qg = reinterpret_cast<float *>(qg_ptr);
+  float *d_kg = reinterpret_cast<float *>(kg_ptr);
+  float *d_vg = reinterpret_cast<float *>(vg_ptr);
 
-    bf16*  d_q  = reinterpret_cast<bf16*>(q_ptr);
-    bf16*  d_k  = reinterpret_cast<bf16*>(k_ptr);
-    bf16*  d_v  = reinterpret_cast<bf16*>(v_ptr);
-    bf16*  d_o  = reinterpret_cast<bf16*>(o_ptr);
-    bf16*  d_og = reinterpret_cast<bf16*>(og_ptr);
-    float* d_l  = reinterpret_cast<float*>(l_ptr);
-    float* d_d  = reinterpret_cast<float*>(d_ptr);
-    float* d_qg = reinterpret_cast<float*>(qg_ptr);
-    float* d_kg = reinterpret_cast<float*>(kg_ptr);
-    float* d_vg = reinterpret_cast<float*>(vg_ptr);
+  constexpr int mem_size = kittens::MAX_SHARED_MEMORY;
+  int threads = 4 * kittens::WARP_THREADS;
 
-    constexpr int mem_size = kittens::MAX_SHARED_MEMORY; 
-    int threads  = 4 * kittens::WARP_THREADS;
+  // cudadevicesynchronize();
+  const c10::cuda::OptionalCUDAGuard device_guard(q.device());
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
 
-    //cudadevicesynchronize();
-    const c10::cuda::OptionalCUDAGuard device_guard(q.device());    
-    const cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream(); 
+  //  cudaStreamSynchronize(stream);
 
-    //  cudaStreamSynchronize(stream);
+  // TORCH_CHECK(seq_len % (4*kittens::TILE_DIM*4) == 0, "sequence length must
+  // be divisible by 256");
+  dim3 grid_bwd(seq_len / (4 * kittens::TILE_ROW_DIM<bf16> * 4), qo_heads,
+                batch);
 
-    // TORCH_CHECK(seq_len % (4*kittens::TILE_DIM*4) == 0, "sequence length must be divisible by 256");
-    dim3 grid_bwd(seq_len/(4*kittens::TILE_ROW_DIM<bf16>*4), qo_heads, batch);
+  if (head_dim == 64) {
+    using og_tile = st_bf<4 * 16, 64>;
+    using o_tile = st_bf<4 * 16, 64>;
+    using d_tile = col_vec<st_fl<4 * 16, 64>>;
 
-    if (head_dim == 64)  {
-        using og_tile = st_bf<4*16, 64>;
-        using o_tile  = st_bf<4*16, 64>;
-        using d_tile  = col_vec<st_fl<4*16, 64>>;
+    using og_global = gl<bf16, -1, -1, -1, -1, og_tile>;
+    using o_global = gl<bf16, -1, -1, -1, -1, o_tile>;
+    using d_global = gl<float, -1, -1, -1, -1, d_tile>;
 
-        using og_global = gl<bf16,  -1, -1, -1, -1, og_tile>;
-        using o_global  = gl<bf16,  -1, -1, -1, -1, o_tile>;
-        using d_global  = gl<float, -1, -1, -1, -1, d_tile>;
+    using bwd_prep_globals = bwd_prep_globals<64>;
 
-        using bwd_prep_globals = bwd_prep_globals<64>;
+    og_global prep_og_arg{d_og, static_cast<unsigned int>(batch),
+                          static_cast<unsigned int>(qo_heads),
+                          static_cast<unsigned int>(seq_len), 64U};
+    o_global prep_o_arg{d_o, static_cast<unsigned int>(batch),
+                        static_cast<unsigned int>(qo_heads),
+                        static_cast<unsigned int>(seq_len), 64U};
+    d_global prep_d_arg{d_d, static_cast<unsigned int>(batch),
+                        static_cast<unsigned int>(qo_heads), 1U,
+                        static_cast<unsigned int>(seq_len)};
 
-        og_global prep_og_arg{d_og, static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), static_cast<unsigned int>(seq_len), 64U};
-        o_global  prep_o_arg {d_o,  static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), static_cast<unsigned int>(seq_len), 64U};
-        d_global  prep_d_arg {d_d,  static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), 1U,  static_cast<unsigned int>(seq_len)};
+    bwd_prep_globals bwd_g{prep_og_arg, prep_o_arg, prep_d_arg};
 
-        bwd_prep_globals bwd_g{prep_og_arg, prep_o_arg, prep_d_arg};
+    cudaFuncSetAttribute(bwd_attend_prep_ker<64>,
+                         cudaFuncAttributeMaxDynamicSharedMemorySize, mem_size);
 
-        cudaFuncSetAttribute(
-            bwd_attend_prep_ker<64>,
-            cudaFuncAttributeMaxDynamicSharedMemorySize,
-            mem_size
-        );
+    bwd_attend_prep_ker<64><<<grid_bwd, threads, mem_size, stream>>>(bwd_g);
 
-        bwd_attend_prep_ker<64><<<grid_bwd, threads, mem_size, stream>>>(bwd_g); 
+    using bwd_q_tile = st_bf<bwd_attend_ker_tile_dims<64>::tile_h_qo,
+                             bwd_attend_ker_tile_dims<64>::tile_width>;
+    using bwd_k_tile = st_bf<bwd_attend_ker_tile_dims<64>::tile_h,
+                             bwd_attend_ker_tile_dims<64>::tile_width>;
+    using bwd_v_tile = st_bf<bwd_attend_ker_tile_dims<64>::tile_h,
+                             bwd_attend_ker_tile_dims<64>::tile_width>;
+    using bwd_og_tile = st_bf<bwd_attend_ker_tile_dims<64>::tile_h_qo,
+                              bwd_attend_ker_tile_dims<64>::tile_width>;
+    using bwd_qg_tile = st_fl<bwd_attend_ker_tile_dims<64>::tile_h_qo,
+                              bwd_attend_ker_tile_dims<64>::tile_width>;
+    using bwd_kg_tile = st_fl<bwd_attend_ker_tile_dims<64>::tile_h,
+                              bwd_attend_ker_tile_dims<64>::tile_width>;
+    using bwd_vg_tile = st_fl<bwd_attend_ker_tile_dims<64>::tile_h,
+                              bwd_attend_ker_tile_dims<64>::tile_width>;
+    using bwd_l_tile = row_vec<st_fl<bwd_attend_ker_tile_dims<64>::tile_h_qo,
+                                     bwd_attend_ker_tile_dims<64>::tile_h>>;
+    using bwd_d_tile = row_vec<st_fl<bwd_attend_ker_tile_dims<64>::tile_h_qo,
+                                     bwd_attend_ker_tile_dims<64>::tile_h>>;
 
-        using bwd_q_tile    =         st_bf<bwd_attend_ker_tile_dims<64>::tile_h_qo, bwd_attend_ker_tile_dims<64>::tile_width>;
-        using bwd_k_tile    =         st_bf<bwd_attend_ker_tile_dims<64>::tile_h,    bwd_attend_ker_tile_dims<64>::tile_width>;
-        using bwd_v_tile    =         st_bf<bwd_attend_ker_tile_dims<64>::tile_h,    bwd_attend_ker_tile_dims<64>::tile_width>;
-        using bwd_og_tile   =         st_bf<bwd_attend_ker_tile_dims<64>::tile_h_qo, bwd_attend_ker_tile_dims<64>::tile_width>;
-        using bwd_qg_tile   =         st_fl<bwd_attend_ker_tile_dims<64>::tile_h_qo, bwd_attend_ker_tile_dims<64>::tile_width>;
-        using bwd_kg_tile   =         st_fl<bwd_attend_ker_tile_dims<64>::tile_h,    bwd_attend_ker_tile_dims<64>::tile_width>;
-        using bwd_vg_tile   =         st_fl<bwd_attend_ker_tile_dims<64>::tile_h,    bwd_attend_ker_tile_dims<64>::tile_width>;
-        using bwd_l_tile    = row_vec<st_fl<bwd_attend_ker_tile_dims<64>::tile_h_qo, bwd_attend_ker_tile_dims<64>::tile_h>>;
-        using bwd_d_tile    = row_vec<st_fl<bwd_attend_ker_tile_dims<64>::tile_h_qo, bwd_attend_ker_tile_dims<64>::tile_h>>;
+    using bwd_q_global = gl<bf16, -1, -1, -1, -1, bwd_q_tile>;
+    using bwd_k_global = gl<bf16, -1, -1, -1, -1, bwd_k_tile>;
+    using bwd_v_global = gl<bf16, -1, -1, -1, -1, bwd_v_tile>;
 
-        using bwd_q_global  = gl<bf16,  -1, -1, -1, -1, bwd_q_tile>;
-        using bwd_k_global  = gl<bf16,  -1, -1, -1, -1, bwd_k_tile>;
-        using bwd_v_global  = gl<bf16,  -1, -1, -1, -1, bwd_v_tile>;
+    using bwd_og_global = gl<bf16, -1, -1, -1, -1, bwd_og_tile>;
 
-        using bwd_og_global = gl<bf16,  -1, -1, -1, -1, bwd_og_tile>;
+    using bwd_qg_global = gl<float, -1, -1, -1, -1, bwd_qg_tile>;
+    using bwd_kg_global = gl<float, -1, -1, -1, -1, bwd_kg_tile>;
+    using bwd_vg_global = gl<float, -1, -1, -1, -1, bwd_vg_tile>;
 
-        using bwd_qg_global = gl<float, -1, -1, -1, -1, bwd_qg_tile>;
-        using bwd_kg_global = gl<float, -1, -1, -1, -1, bwd_kg_tile>;
-        using bwd_vg_global = gl<float, -1, -1, -1, -1, bwd_vg_tile>;
+    using bwd_l_global = gl<float, -1, -1, -1, -1, bwd_l_tile>;
+    using bwd_d_global = gl<float, -1, -1, -1, -1, bwd_d_tile>;
 
-        using bwd_l_global  = gl<float, -1, -1, -1, -1, bwd_l_tile>;
-        using bwd_d_global  = gl<float, -1, -1, -1, -1, bwd_d_tile>;
+    using bwd_global_args = bwd_globals<64>;
 
-        using bwd_global_args = bwd_globals<64>;
+    bwd_q_global bwd_q_arg{d_q, static_cast<unsigned int>(batch),
+                           static_cast<unsigned int>(qo_heads),
+                           static_cast<unsigned int>(seq_len), 64U};
+    bwd_k_global bwd_k_arg{d_k, static_cast<unsigned int>(batch),
+                           static_cast<unsigned int>(kv_heads),
+                           static_cast<unsigned int>(seq_len*CP), 64U};
+    bwd_v_global bwd_v_arg{d_v, static_cast<unsigned int>(batch),
+                           static_cast<unsigned int>(kv_heads),
+                           static_cast<unsigned int>(seq_len*CP), 64U};
+    bwd_og_global bwd_og_arg{d_og, static_cast<unsigned int>(batch),
+                             static_cast<unsigned int>(qo_heads),
+                             static_cast<unsigned int>(seq_len), 64U};
+    bwd_qg_global bwd_qg_arg{d_qg, static_cast<unsigned int>(batch),
+                             static_cast<unsigned int>(qo_heads),
+                             static_cast<unsigned int>(seq_len), 64U};
+    bwd_kg_global bwd_kg_arg{d_kg, static_cast<unsigned int>(batch),
+                             static_cast<unsigned int>(kv_heads),
+                             static_cast<unsigned int>(seq_len*CP), 64U};
+    bwd_vg_global bwd_vg_arg{d_vg, static_cast<unsigned int>(batch),
+                             static_cast<unsigned int>(kv_heads),
+                             static_cast<unsigned int>(seq_len*CP), 64U};
+    bwd_l_global bwd_l_arg{d_l, static_cast<unsigned int>(batch),
+                           static_cast<unsigned int>(qo_heads), 1U,
+                           static_cast<unsigned int>(seq_len)};
+    bwd_d_global bwd_d_arg{d_d, static_cast<unsigned int>(batch),
+                           static_cast<unsigned int>(qo_heads), 1U,
+                           static_cast<unsigned int>(seq_len)};
 
-        bwd_q_global  bwd_q_arg {d_q,  static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), static_cast<unsigned int>(seq_len), 64U};
-        bwd_k_global  bwd_k_arg {d_k,  static_cast<unsigned int>(batch), static_cast<unsigned int>(kv_heads), static_cast<unsigned int>(seq_len), 64U};
-        bwd_v_global  bwd_v_arg {d_v,  static_cast<unsigned int>(batch), static_cast<unsigned int>(kv_heads), static_cast<unsigned int>(seq_len), 64U};
-        bwd_og_global bwd_og_arg{d_og, static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), static_cast<unsigned int>(seq_len), 64U};
-        bwd_qg_global bwd_qg_arg{d_qg, static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), static_cast<unsigned int>(seq_len), 64U};
-        bwd_kg_global bwd_kg_arg{d_kg, static_cast<unsigned int>(batch), static_cast<unsigned int>(kv_heads), static_cast<unsigned int>(seq_len), 64U};
-        bwd_vg_global bwd_vg_arg{d_vg, static_cast<unsigned int>(batch), static_cast<unsigned int>(kv_heads), static_cast<unsigned int>(seq_len), 64U};
-        bwd_l_global  bwd_l_arg {d_l,  static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), 1U,  static_cast<unsigned int>(seq_len)};
-        bwd_d_global  bwd_d_arg {d_d,  static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), 1U,  static_cast<unsigned int>(seq_len)};
+    bwd_global_args bwd_global{
+        bwd_q_arg,
+        bwd_k_arg,
+        bwd_v_arg,
+        bwd_og_arg,
+        bwd_qg_arg,
+        bwd_kg_arg,
+        bwd_vg_arg,
+        bwd_l_arg,
+        bwd_d_arg,
+        static_cast<int>(seq_len),
+        static_cast<int>(hr),
+        static_cast<int>(max_q_blocks_per_kv),
+        reinterpret_cast<int32_t *>(k2q_block_sparse_index.data_ptr()),
+        reinterpret_cast<int32_t *>(k2q_block_sparse_num.data_ptr())};
 
-        bwd_global_args bwd_global{bwd_q_arg, 
-                        bwd_k_arg, 
-                        bwd_v_arg, 
-                        bwd_og_arg, 
-                        bwd_qg_arg, 
-                        bwd_kg_arg, 
-                        bwd_vg_arg, 
-                        bwd_l_arg, 
-                        bwd_d_arg, 
-                        static_cast<int>(seq_len), 
-                        static_cast<int>(hr),
-                        static_cast<int>(max_q_blocks_per_kv),
-                        reinterpret_cast<int32_t*>(k2q_block_sparse_index.data_ptr()),
-                        reinterpret_cast<int32_t*>(k2q_block_sparse_num.data_ptr())
-                        };
+    dim3 grid_bwd_2(seq_len / 64, qo_heads, batch);
+    threads = 128;
 
-        dim3 grid_bwd_2(seq_len/64, qo_heads, batch);
-        threads = 128;
+    // cudadevicesynchronize();
 
-        //cudadevicesynchronize();
+    {
+      cudaFuncSetAttribute(bwd_attend_ker<64>,
+                           cudaFuncAttributeMaxDynamicSharedMemorySize, 72000);
+      // cudaFuncSetAttribute(
+      //     bwd_attend_ker<64>,
+      //     cudaFuncAttributePreferredSharedMemoryCarveout,
+      //     85
+      // );
 
-        {
-            cudaFuncSetAttribute(
-                bwd_attend_ker<64>,
-                cudaFuncAttributeMaxDynamicSharedMemorySize,
-                72000
-            );
-            // cudaFuncSetAttribute(
-            //     bwd_attend_ker<64>,
-            //     cudaFuncAttributePreferredSharedMemoryCarveout,
-            //     85
-            // );
-            
-            bwd_attend_ker<64><<<grid_bwd_2, threads, 72000, stream>>>(bwd_global); 
-        }
-
-        // CHECK_CUDA_ERROR(cudaGetLastError());
-        // cudaStreamSynchronize(stream);
-        //cudadevicesynchronize();
-        // const auto kernel_end = std::chrono::high_resolution_clock::now();
-        // std::cout << "Kernel Time: " << std::chrono::duration_cast<std::chrono::microseconds>(kernel_end - start).count() << "us" << std::endl;
-        // std::cout << "---" << std::endl;
+      bwd_attend_ker<64><<<grid_bwd_2, threads, 72000, stream>>>(bwd_global);
     }
 
-    if (head_dim == 128) {
-        using og_tile = st_bf<4*16, 128>;
-        using o_tile  = st_bf<4*16, 128>;
-        using d_tile  = col_vec<st_fl<4*16, 128>>;
+    // CHECK_CUDA_ERROR(cudaGetLastError());
+    // cudaStreamSynchronize(stream);
+    // cudadevicesynchronize();
+    // const auto kernel_end = std::chrono::high_resolution_clock::now();
+    // std::cout << "Kernel Time: " <<
+    // std::chrono::duration_cast<std::chrono::microseconds>(kernel_end -
+    // start).count() << "us" << std::endl; std::cout << "---" << std::endl;
+  }
 
-        using og_global = gl<bf16,  -1, -1, -1, -1, og_tile>;
-        using o_global  = gl<bf16,  -1, -1, -1, -1, o_tile>;
-        using d_global  = gl<float, -1, -1, -1, -1, d_tile>;
+  if (head_dim == 128) {
+    using og_tile = st_bf<4 * 16, 128>;
+    using o_tile = st_bf<4 * 16, 128>;
+    using d_tile = col_vec<st_fl<4 * 16, 128>>;
 
-        using bwd_prep_globals = bwd_prep_globals<128>;
+    using og_global = gl<bf16, -1, -1, -1, -1, og_tile>;
+    using o_global = gl<bf16, -1, -1, -1, -1, o_tile>;
+    using d_global = gl<float, -1, -1, -1, -1, d_tile>;
 
-        og_global prep_og_arg{d_og, static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), static_cast<unsigned int>(seq_len), 128U};
-        o_global  prep_o_arg {d_o,  static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), static_cast<unsigned int>(seq_len), 128U};
-        d_global  prep_d_arg {d_d,  static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), 1U,  static_cast<unsigned int>(seq_len)};
+    using bwd_prep_globals = bwd_prep_globals<128>;
 
-        bwd_prep_globals bwd_g{prep_og_arg, prep_o_arg, prep_d_arg};
+    og_global prep_og_arg{d_og, static_cast<unsigned int>(batch),
+                          static_cast<unsigned int>(qo_heads),
+                          static_cast<unsigned int>(seq_len), 128U};
+    o_global prep_o_arg{d_o, static_cast<unsigned int>(batch),
+                        static_cast<unsigned int>(qo_heads),
+                        static_cast<unsigned int>(seq_len), 128U};
+    d_global prep_d_arg{d_d, static_cast<unsigned int>(batch),
+                        static_cast<unsigned int>(qo_heads), 1U,
+                        static_cast<unsigned int>(seq_len)};
 
-        cudaFuncSetAttribute(
-            bwd_attend_prep_ker<128>,
-            cudaFuncAttributeMaxDynamicSharedMemorySize,
-            mem_size
-        );
+    bwd_prep_globals bwd_g{prep_og_arg, prep_o_arg, prep_d_arg};
 
-        bwd_attend_prep_ker<128><<<grid_bwd, threads, mem_size, stream>>>(bwd_g); 
+    cudaFuncSetAttribute(bwd_attend_prep_ker<128>,
+                         cudaFuncAttributeMaxDynamicSharedMemorySize, mem_size);
 
-        using bwd_q_tile    =         st_bf<bwd_attend_ker_tile_dims<128>::tile_h_qo, bwd_attend_ker_tile_dims<128>::tile_width>;
-        using bwd_k_tile    =         st_bf<bwd_attend_ker_tile_dims<128>::tile_h,    bwd_attend_ker_tile_dims<128>::tile_width>;
-        using bwd_v_tile    =         st_bf<bwd_attend_ker_tile_dims<128>::tile_h,    bwd_attend_ker_tile_dims<128>::tile_width>;
-        using bwd_og_tile   =         st_bf<bwd_attend_ker_tile_dims<128>::tile_h_qo, bwd_attend_ker_tile_dims<128>::tile_width>;
-        using bwd_qg_tile   =         st_fl<bwd_attend_ker_tile_dims<128>::tile_h_qo, bwd_attend_ker_tile_dims<128>::tile_width>;
-        using bwd_kg_tile   =         st_fl<bwd_attend_ker_tile_dims<128>::tile_h,    bwd_attend_ker_tile_dims<128>::tile_width>;
-        using bwd_vg_tile   =         st_fl<bwd_attend_ker_tile_dims<128>::tile_h,    bwd_attend_ker_tile_dims<128>::tile_width>;
-        using bwd_l_tile    = row_vec<st_fl<bwd_attend_ker_tile_dims<128>::tile_h_qo, bwd_attend_ker_tile_dims<128>::tile_h>>;
-        using bwd_d_tile    = row_vec<st_fl<bwd_attend_ker_tile_dims<128>::tile_h_qo, bwd_attend_ker_tile_dims<128>::tile_h>>;
+    bwd_attend_prep_ker<128><<<grid_bwd, threads, mem_size, stream>>>(bwd_g);
 
-        using bwd_q_global  = gl<bf16,  -1, -1, -1, -1, bwd_q_tile>;
-        using bwd_k_global  = gl<bf16,  -1, -1, -1, -1, bwd_k_tile>;
-        using bwd_v_global  = gl<bf16,  -1, -1, -1, -1, bwd_v_tile>;
+    using bwd_q_tile = st_bf<bwd_attend_ker_tile_dims<128>::tile_h_qo,
+                             bwd_attend_ker_tile_dims<128>::tile_width>;
+    using bwd_k_tile = st_bf<bwd_attend_ker_tile_dims<128>::tile_h,
+                             bwd_attend_ker_tile_dims<128>::tile_width>;
+    using bwd_v_tile = st_bf<bwd_attend_ker_tile_dims<128>::tile_h,
+                             bwd_attend_ker_tile_dims<128>::tile_width>;
+    using bwd_og_tile = st_bf<bwd_attend_ker_tile_dims<128>::tile_h_qo,
+                              bwd_attend_ker_tile_dims<128>::tile_width>;
+    using bwd_qg_tile = st_fl<bwd_attend_ker_tile_dims<128>::tile_h_qo,
+                              bwd_attend_ker_tile_dims<128>::tile_width>;
+    using bwd_kg_tile = st_fl<bwd_attend_ker_tile_dims<128>::tile_h,
+                              bwd_attend_ker_tile_dims<128>::tile_width>;
+    using bwd_vg_tile = st_fl<bwd_attend_ker_tile_dims<128>::tile_h,
+                              bwd_attend_ker_tile_dims<128>::tile_width>;
+    using bwd_l_tile = row_vec<st_fl<bwd_attend_ker_tile_dims<128>::tile_h_qo,
+                                     bwd_attend_ker_tile_dims<128>::tile_h>>;
+    using bwd_d_tile = row_vec<st_fl<bwd_attend_ker_tile_dims<128>::tile_h_qo,
+                                     bwd_attend_ker_tile_dims<128>::tile_h>>;
 
-        using bwd_og_global = gl<bf16,  -1, -1, -1, -1, bwd_og_tile>;
+    using bwd_q_global = gl<bf16, -1, -1, -1, -1, bwd_q_tile>;
+    using bwd_k_global = gl<bf16, -1, -1, -1, -1, bwd_k_tile>;
+    using bwd_v_global = gl<bf16, -1, -1, -1, -1, bwd_v_tile>;
 
-        using bwd_qg_global = gl<float, -1, -1, -1, -1, bwd_qg_tile>;
-        using bwd_kg_global = gl<float, -1, -1, -1, -1, bwd_kg_tile>;
-        using bwd_vg_global = gl<float, -1, -1, -1, -1, bwd_vg_tile>;
+    using bwd_og_global = gl<bf16, -1, -1, -1, -1, bwd_og_tile>;
 
-        using bwd_l_global  = gl<float, -1, -1, -1, -1, bwd_l_tile>;
-        using bwd_d_global  = gl<float, -1, -1, -1, -1, bwd_d_tile>;
+    using bwd_qg_global = gl<float, -1, -1, -1, -1, bwd_qg_tile>;
+    using bwd_kg_global = gl<float, -1, -1, -1, -1, bwd_kg_tile>;
+    using bwd_vg_global = gl<float, -1, -1, -1, -1, bwd_vg_tile>;
 
-        using bwd_global_args = bwd_globals<128>;
+    using bwd_l_global = gl<float, -1, -1, -1, -1, bwd_l_tile>;
+    using bwd_d_global = gl<float, -1, -1, -1, -1, bwd_d_tile>;
 
-        bwd_q_global  bwd_q_arg {d_q,  static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), static_cast<unsigned int>(seq_len), 128U};
-        bwd_k_global  bwd_k_arg {d_k,  static_cast<unsigned int>(batch), static_cast<unsigned int>(kv_heads), static_cast<unsigned int>(seq_len), 128U};
-        bwd_v_global  bwd_v_arg {d_v,  static_cast<unsigned int>(batch), static_cast<unsigned int>(kv_heads), static_cast<unsigned int>(seq_len), 128U};
-        bwd_og_global bwd_og_arg{d_og, static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), static_cast<unsigned int>(seq_len), 128U};
-        bwd_qg_global bwd_qg_arg{d_qg, static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), static_cast<unsigned int>(seq_len), 128U};
-        bwd_kg_global bwd_kg_arg{d_kg, static_cast<unsigned int>(batch), static_cast<unsigned int>(kv_heads), static_cast<unsigned int>(seq_len), 128U};
-        bwd_vg_global bwd_vg_arg{d_vg, static_cast<unsigned int>(batch), static_cast<unsigned int>(kv_heads), static_cast<unsigned int>(seq_len), 128U};
-        bwd_l_global  bwd_l_arg {d_l,  static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), 1U,  static_cast<unsigned int>(seq_len)};
-        bwd_d_global  bwd_d_arg {d_d,  static_cast<unsigned int>(batch), static_cast<unsigned int>(qo_heads), 1U,  static_cast<unsigned int>(seq_len)};
+    using bwd_global_args = bwd_globals<128>;
 
-        bwd_global_args bwd_global{bwd_q_arg, 
-                        bwd_k_arg, 
-                        bwd_v_arg, 
-                        bwd_og_arg, 
-                        bwd_qg_arg, 
-                        bwd_kg_arg, 
-                        bwd_vg_arg, 
-                        bwd_l_arg, 
-                        bwd_d_arg, 
-                        static_cast<int>(seq_len), 
-                        static_cast<int>(hr),
-                        static_cast<int>(max_q_blocks_per_kv),
-                        reinterpret_cast<int32_t*>(k2q_block_sparse_index.data_ptr()),
-                        reinterpret_cast<int32_t*>(k2q_block_sparse_num.data_ptr())
-                        };
+    bwd_q_global bwd_q_arg{d_q, static_cast<unsigned int>(batch),
+                           static_cast<unsigned int>(qo_heads),
+                           static_cast<unsigned int>(seq_len), 128U};
+    bwd_k_global bwd_k_arg{d_k, static_cast<unsigned int>(batch),
+                           static_cast<unsigned int>(kv_heads),
+                           static_cast<unsigned int>(seq_len*CP), 128U};
+    bwd_v_global bwd_v_arg{d_v, static_cast<unsigned int>(batch),
+                           static_cast<unsigned int>(kv_heads),
+                           static_cast<unsigned int>(seq_len*CP), 128U};
+    bwd_og_global bwd_og_arg{d_og, static_cast<unsigned int>(batch),
+                             static_cast<unsigned int>(qo_heads),
+                             static_cast<unsigned int>(seq_len), 128U};
+    bwd_qg_global bwd_qg_arg{d_qg, static_cast<unsigned int>(batch),
+                             static_cast<unsigned int>(qo_heads),
+                             static_cast<unsigned int>(seq_len), 128U};
+    bwd_kg_global bwd_kg_arg{d_kg, static_cast<unsigned int>(batch),
+                             static_cast<unsigned int>(kv_heads),
+                             static_cast<unsigned int>(seq_len*CP), 128U};
+    bwd_vg_global bwd_vg_arg{d_vg, static_cast<unsigned int>(batch),
+                             static_cast<unsigned int>(kv_heads),
+                             static_cast<unsigned int>(seq_len*CP), 128U};
+    bwd_l_global bwd_l_arg{d_l, static_cast<unsigned int>(batch),
+                           static_cast<unsigned int>(qo_heads), 1U,
+                           static_cast<unsigned int>(seq_len)};
+    bwd_d_global bwd_d_arg{d_d, static_cast<unsigned int>(batch),
+                           static_cast<unsigned int>(qo_heads), 1U,
+                           static_cast<unsigned int>(seq_len)};
 
-        dim3 grid_bwd_2(seq_len/64, qo_heads, batch);
-        threads = 128;
+    bwd_global_args bwd_global{
+        bwd_q_arg,
+        bwd_k_arg,
+        bwd_v_arg,
+        bwd_og_arg,
+        bwd_qg_arg,
+        bwd_kg_arg,
+        bwd_vg_arg,
+        bwd_l_arg,
+        bwd_d_arg,
+        static_cast<int>(seq_len),
+        static_cast<int>(hr),
+        static_cast<int>(max_q_blocks_per_kv),
+        reinterpret_cast<int32_t *>(k2q_block_sparse_index.data_ptr()),
+        reinterpret_cast<int32_t *>(k2q_block_sparse_num.data_ptr())};
 
-        //cudadevicesynchronize();
+    dim3 grid_bwd_2(seq_len / 64, qo_heads, batch);
+    threads = 128;
 
-        {
-            cudaFuncSetAttribute(
-                bwd_attend_ker<128>,
-                cudaFuncAttributeMaxDynamicSharedMemorySize,
-                113000
-            );
-            
-            bwd_attend_ker<128><<<grid_bwd_2, threads, 113000, stream>>>(bwd_global); 
-        }
+    // cudadevicesynchronize();
 
-        // cudaStreamSynchronize(stream);
-        //cudadevicesynchronize();
+    {
+      cudaFuncSetAttribute(bwd_attend_ker<128>,
+                           cudaFuncAttributeMaxDynamicSharedMemorySize, 113000);
+
+      bwd_attend_ker<128><<<grid_bwd_2, threads, 113000, stream>>>(bwd_global);
     }
 
-    return {qg, kg, vg};
-    //cudadevicesynchronize();
+    // cudaStreamSynchronize(stream);
+    // cudadevicesynchronize();
+  }
+
+  return {qg, kg, vg};
+  // cudadevicesynchronize();
 }


### PR DESCRIPTION
Added correctness checking tool (csrc/attn/check_correctness.py) between FA3, Torch attention VSA and FlexAttention.
Added FlexAttention VSA (csrc/attn/flex_attn_vsa.py) which can be seen as reference of both dense attention bwd and sparse attention bwd.
Updated the VSA kernel (csrc/attn/vsa/block_sparse_h100.cu) to handle CP = 4 - we verify its fwd is correct but bwd is incorrect.