### PR TITLE
Fix VSA bwd's incorrectness by launching kernels correctly

### DIFF
--- a/csrc/attn/bench_CP.py
+++ b/csrc/attn/bench_CP.py
@@ -1,0 +1,76 @@
+
+import torch
+import torch.nn.functional as F
+from xformers.ops import fmha, memory_efficient_attention
+from vsa import video_sparse_attn
+from flex_attn_vsa import VSA_attention_flex
+import numpy as np
+
+def FA3(q, k, v):
+    # FA3
+    output = memory_efficient_attention(q, k, v, attn_bias=None)
+    return output
+
+
+def VSA(q,k,v):
+    # VSA
+    output_VSA = video_sparse_attn(q, k, v, topk=topk_blocks, block_size=(4,4,4), compress_attn_weight=0.0)
+    return output_VSA
+
+
+def VSA_flex(q,k,v):
+    # VSA-flex
+    output_flex = VSA_attention_flex(q,k,v, topk=topk_blocks, block_size=(4,4,4), compress_attn_weight=0.0)
+    return output_flex
+
+
+# setup random seed
+torch.manual_seed(42)
+
+# random inputs
+batch_size = 1
+# seq_len = 36864
+# seq_len = 73728
+seq_len = 147456
+head_num = 12
+head_dim = 128
+block_size = 64
+CP = 2 # context parallelism
+q = torch.randn(batch_size, seq_len//CP, head_num, head_dim, requires_grad=True, dtype=torch.bfloat16, device="cuda")
+k = torch.randn(batch_size, seq_len, head_num, head_dim, requires_grad=True, dtype=torch.bfloat16, device="cuda")
+v = torch.randn(batch_size, seq_len, head_num, head_dim, requires_grad=True, dtype=torch.bfloat16, device="cuda")
+topk_blocks = int(0.125 * seq_len/block_size) # select all blocks, causing dense attention
+print("topk_blocks:", topk_blocks)
+q, k, v = q.permute(0,2,1,3).contiguous(), k.permute(0,2,1,3).contiguous(), v.permute(0,2,1,3).contiguous()
+# fwd
+for i in range(2):
+    # output_FA3 = FA3(q, k, v)
+    _ = VSA(q,k,v)
+    # _ = VSA_flex(q,k,v)
+
+num_iters = 500
+start_event = [torch.cuda.Event(enable_timing=True) for _ in range(num_iters)]
+end_event = [torch.cuda.Event(enable_timing=True) for _ in range(num_iters)]
+torch.cuda.synchronize()
+
+for i in range(num_iters):
+    if torch.distributed.is_initialized():
+        torch.distributed.barrier()
+    start_event[i].record()
+    # output_FA3 = FA3(q, k, v)
+    # # output_VSA = VSA(q.permute(0,2,1,3).contiguous(), k.permute(0,2,1,3).contiguous(), v.permute(0,2,1,3).contiguous()).permute(0,2,1,3)
+    _ = VSA(q,k,v)
+    # _ = VSA_flex(q,k,v)
+    # output_VSA_flex = VSA_flex(q.permute(0,2,1,3), k.permute(0,2,1,3), v.permute(0,2,1,3)).permute(0,2,1,3)
+    end_event[i].record()
+    torch.cuda.synchronize()
+
+times = np.array([s.elapsed_time(e) for s, e in zip(start_event, end_event)])
+elapsed_time = np.mean(times) * 1.0e-3
+print(f"Average latency: {elapsed_time:.4f} s")
+
+
+
+# Verify the fwd consistency with FA3
+# print("@fwd, consistent between FA3 and FA3 and VSA:", torch.allclose(output_FA3, output_VSA, atol=3e-03, equal_nan=False))
+# print("@fwd, consistent between FA3 and FA3 and VSA:", torch.allclose(output_FA3, output_VSA_flex, atol=3e-03, equal_nan=False))

--- a/csrc/attn/check_correctness.py
+++ b/csrc/attn/check_correctness.py
@@ -33,11 +33,12 @@ torch.manual_seed(42)
 
 # random inputs
 batch_size = 1
-seq_len = 4096
+# seq_len = 8192
+seq_len = 16384
 head_num = 12
 head_dim = 64
 block_size = 64
-CP = 4 # context parallelism
+CP = 2 # context parallelism
 q = torch.randn(batch_size, seq_len//CP, head_num, head_dim, requires_grad=True, dtype=torch.bfloat16, device="cuda")
 k = torch.randn(batch_size, seq_len, head_num, head_dim, requires_grad=True, dtype=torch.bfloat16, device="cuda")
 v = torch.randn(batch_size, seq_len, head_num, head_dim, requires_grad=True, dtype=torch.bfloat16, device="cuda")

--- a/csrc/attn/flex_attn_vsa.py
+++ b/csrc/attn/flex_attn_vsa.py
@@ -130,7 +130,7 @@ def VSA_attention_flex(
         .view(query.shape)
     ) # B H Nq d
 
-    print("output_coarse.shape", output_coarse.shape)
+    # print("output_coarse.shape", output_coarse.shape)
 
     # Topk Selection
     _, topk_indices = torch.topk(block_attn_score, topk, dim=-1)

--- a/csrc/attn/vsa/block_sparse_h100.cu
+++ b/csrc/attn/vsa/block_sparse_h100.cu
@@ -1573,7 +1573,7 @@ std::vector<torch::Tensor> block_sparse_attention_backward(
         reinterpret_cast<int32_t *>(k2q_block_sparse_index.data_ptr()),
         reinterpret_cast<int32_t *>(k2q_block_sparse_num.data_ptr())};
 
-    dim3 grid_bwd_2(seq_len / 64, qo_heads, batch);
+    dim3 grid_bwd_2(seq_len * CP / 64, qo_heads, batch);
     threads = 128;
 
     // cudadevicesynchronize();

--- a/csrc/attn/vsa/block_sparse_h100.cu
+++ b/csrc/attn/vsa/block_sparse_h100.cu
@@ -9,7 +9,7 @@ using namespace kittens;
 namespace cg = cooperative_groups;
 constexpr int BLOCK_M = 64;
 constexpr int BLOCK_N = 64;
-constexpr int CP = 4;
+constexpr int CP = 2;
 template <int D> struct fwd_attend_ker_tile_dims {};
 template <> struct fwd_attend_ker_tile_dims<64> {
   constexpr static int tile_width = (64);
@@ -1332,7 +1332,7 @@ std::vector<torch::Tensor> block_sparse_attention_backward(
 
   // TORCH_CHECK(seq_len % (4*kittens::TILE_DIM*4) == 0, "sequence length must
   // be divisible by 256");
-  dim3 grid_bwd(seq_len / (4 * kittens::TILE_ROW_DIM<bf16> * 4), qo_heads,
+  dim3 grid_bwd(seq_len * CP / (4 * kittens::TILE_ROW_DIM<bf16> * 4), qo_heads,
                 batch);
 
   if (head_dim == 64) {
@@ -1441,7 +1441,7 @@ std::vector<torch::Tensor> block_sparse_attention_backward(
         reinterpret_cast<int32_t *>(k2q_block_sparse_index.data_ptr()),
         reinterpret_cast<int32_t *>(k2q_block_sparse_num.data_ptr())};
 
-    dim3 grid_bwd_2(seq_len / 64, qo_heads, batch);
+    dim3 grid_bwd_2(seq_len * CP / 64, qo_heads, batch);
     threads = 128;
 
     // cudadevicesynchronize();


### PR DESCRIPTION
Solved the bwd result's incorrectness issue and now we can scale VSA kernel's bwd onto more CP conditions (2,4,8). 
We fixed correct kernel launching layouts, which are also related with kv sequence length during backward. Different from fwd, bwd takes kv_seq loop as the outer loop. 